### PR TITLE
#31 fix: handle cases when no matching version range;

### DIFF
--- a/lib/versioneye/services/version_service.rb
+++ b/lib/versioneye/services/version_service.rb
@@ -206,7 +206,7 @@ class VersionService < Versioneye::Service
   #nuget allows to specify version by combining greater_than and smaller_than
   def self.intersect_versions(versions1, versions2, range = true)
     all_versions = versions1.concat versions2
-    common_version_labels = Set.new(versions1.map(&:version)) & Set.new(versions2.map(&:version))
+    common_version_labels = Set.new(versions1.to_a.map(&:version)) & Set.new(versions2.to_a.map(&:version))
     common_versions = all_versions.keep_if do |ver|
       result = false
       if common_version_labels.include? ver[:version]

--- a/spec/versioneye/parsers/nuget_json_parser_spec.rb
+++ b/spec/versioneye/parsers/nuget_json_parser_spec.rb
@@ -107,6 +107,31 @@ describe NugetJsonParser do
       expect( deps[5].comperator ).to eq("=")
 
     end
+
+    it "parses project even when some product has no matching versions" do
+      product4.versions.delete_all
+      product5.versions.delete_all
+
+      project = parser.parse(test_file_url)
+      expect( project ).not_to be_nil
+
+      expect( project.projectdependencies.size ).to eq(6)
+      deps = project.projectdependencies
+ 
+      expect( deps[0].name ).to eq(product4[:name])
+      expect( deps[0].version_requested ).to eq(product4[:version])
+      expect( deps[0].comperator ).to eq(">=")
+
+      expect( deps[1].name ).to eq(product5[:name])
+      expect( deps[1].version_requested ).to eq(product5[:version])
+      expect( deps[1].comperator ).to eq(">=")
+
+      expect( deps[2].name ).to eq(product6[:name])
+      expect( deps[2].version_requested ).to eq(product6[:version])
+      expect( deps[2].comperator ).to eq("=")
+
+      
+    end
   end
 
 end

--- a/spec/versioneye/parsers/nuget_parser_spec.rb
+++ b/spec/versioneye/parsers/nuget_parser_spec.rb
@@ -404,5 +404,14 @@ describe NugetParser do
       expect(res[:version_label]).to eq('[1.0,2.0]')
       expect(res[:comperator]).to eq('>=x<=')
     end
+
+    it "returns the version label from the file, when product has no matching versions" do
+      res = parser.parse_requested_version('24.12.0', depx, product4)
+
+      expect(res).not_to be_nil
+      expect(res[:version_requested]).to eq('24.12.0')
+      expect(res[:version_label]).to eq('24.12.0')
+      expect(res[:comperator]).to eq('>=')
+    end
   end
 end


### PR DESCRIPTION
It'll now use version_label from the file if there is no matching versions for a product;