### PR TITLE
#257 - fix nugetParser version parser when label doesnt quite match with spec;

### DIFF
--- a/lib/versioneye/parsers/nuget_parser.rb
+++ b/lib/versioneye/parsers/nuget_parser.rb
@@ -10,7 +10,9 @@ class NugetParser < CommonParser
     ident           = "[\\w-]" # identificator aka textual value
     prerelease_info = "\\-(?<prerelease>#{ident}[\\.#{ident}]*)" # matches release info: -alpha.1
     build_info      = "\\+(?<build>#{ident}[\\.#{ident}]*)"      # matches build info
-    version         = "(?<version>(#{numeric})(\\.(#{numeric})(\\.(#{numeric}))?)?)"
+    #version         = "(?<version>(#{numeric})(\\.(#{numeric})(\\.(#{numeric}))?)?)" #old major.minor.patch 
+    version         = "(?<version>(#{numeric})(\\.(#{numeric})(\\.(#{numeric}))*)?)" #matches more than m.m.p
+  
     semver          = "#{version}(#{prerelease_info})?(#{build_info})?"
 
     #version range doc: https://docs.nuget.org/create/versioning#Specifying-Version-Ranges-in-.nuspec-Files
@@ -169,7 +171,7 @@ class NugetParser < CommonParser
       version_data[:version]    = latest.version if latest
       version_data[:comperator] = '>=x<='
     else
-      log.error "NugetParser.parse_version_data | version `#{version}` has wrong format"
+      log.error "NugetParser.parse_version_data | version `#{version}` doesnt match with any parser rules"
       version_data[:version] = "0.0.0-NA"
       version_data[:comperator] = '!='
     end

--- a/spec/fixtures/files/nuget/onwerk_packages.config
+++ b/spec/fixtures/files/nuget/onwerk_packages.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CsQuery" version="1.3.4" targetFramework="net40" />
+  <package id="BuildTools.StyleCop" version="4.7.49.0" targetFramework="net40" />
+  <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net40" />
+  <package id="Onwerk.Mailer" version="1.6.6.0" targetFramework="net40" />
+  <package id="Simple.Data.Ado" version="0.18.3.1" targetFramework="net40" />
+</packages>

--- a/spec/versioneye/parsers/nuget_packages_parser_spec.rb
+++ b/spec/versioneye/parsers/nuget_packages_parser_spec.rb
@@ -49,4 +49,87 @@ describe NugetPackagesParser do
       expect( deps[1].comperator).to eq('=')
     end
   end
+
+  let(:onwerk_file){ File.read "spec/fixtures/files/nuget/onwerk_packages.config" }
+  let(:product3){
+    FactoryGirl.create(
+      :product_with_versions,
+      prod_key: 'CsQuery',
+      name: 'CsQuery',
+      prod_type: Project::A_TYPE_NUGET,
+      language: Product::A_LANGUAGE_CSHARP,
+      version: '1.3.4'
+    )
+  }
+  let(:product4){
+    FactoryGirl.create(
+      :product_with_versions,
+      prod_key: 'BuildTools.StyleCop',
+      name: 'BuildTools.StyleCop',
+      prod_type: Project::A_TYPE_NUGET,
+      language: Product::A_LANGUAGE_CSHARP,
+      version: '4.7.49.0'
+    )
+  }
+  let(:product5){
+    FactoryGirl.create(
+      :product_with_versions,
+      prod_key: 'Microsoft.AspNet.Razor',
+      name: 'Microsoft.AspNet.Razor',
+      prod_type: Project::A_TYPE_NUGET,
+      language: Product::A_LANGUAGE_CSHARP,
+      version: '2.0.30506.0'
+    )
+  }
+  let(:product6){
+    FactoryGirl.build(
+      :product_with_versions,
+      prod_key: 'Onwerk.Mailer',
+      name: 'Onwerk.Mailer',
+      prod_type: Project::A_TYPE_NUGET,
+      language: Product::A_LANGUAGE_CSHARP,
+      version: '1.6.6.0'
+    )
+  }
+  let(:product7){
+    FactoryGirl.create(
+      :product_with_versions,
+      prod_key: 'Simple.Data.Ado',
+      name: 'Simple.Data.Ado',
+      prod_type: Project::A_TYPE_NUGET,
+      language: Product::A_LANGUAGE_CSHARP,
+      version: '0.18.3.1'
+    )
+  }
+
+  context "onwerk's failed project" do
+    it "parses their packages.config correctly" do
+      project = parser.parse_content(onwerk_file, "ftp://spec_test")
+      expect(project).not_to be_nil
+      expect(project.projectdependencies.size).to eq(5)
+
+      deps = project.projectdependencies
+
+      expect( deps[0].name ).to eq(product3[:name])
+      expect( deps[0].version_requested ).to eq(product3[:version])
+      expect( deps[0].comperator).to eq('=')
+
+      expect( deps[1].name ).to eq(product4[:name])
+      expect( deps[1].version_requested ).to eq(product4[:version])
+      expect( deps[1].comperator).to eq('=')
+
+      expect( deps[2].name ).to eq(product5[:name])
+      expect( deps[2].version_requested ).to eq(product5[:version])
+      expect( deps[2].comperator).to eq('=')
+
+      expect( deps[3].name ).to eq(product6[:name])
+      expect( deps[3].version_requested ).to eq(product6[:version])
+      expect( deps[3].comperator).to eq('=')
+
+      expect( deps[4].name ).to eq(product7[:name])
+      expect( deps[4].version_requested ).to eq(product7[:version])
+      expect( deps[4].comperator).to eq('=')
+
+    end
+  end
 end

--- a/spec/versioneye/parsers/nuget_parser_spec.rb
+++ b/spec/versioneye/parsers/nuget_parser_spec.rb
@@ -59,6 +59,16 @@ describe NugetParser do
       expect( "1.0-alpha.1.2+build.2".match(semver) ).not_to be_nil
     end
 
+    it "matches patched_patch semvers" do
+      semver = parser.rules[:semver]
+      
+      expect( semver.match '2.0.30506.0' ).not_to be_nil
+      expect( semver.match '1.6.6.0' ).not_to be_nil
+      expect( semver.match '0.18.3.1' ).not_to be_nil
+      expect( semver.match '0.18.3.1.2.3' ).not_to be_nil
+
+    end
+
     it "matches less than rule" do
       less_than = parser.rules[:less_than]
 


### PR DESCRIPTION
NotNet packages do not have always proper SemVer as Nuget spec requires.

I changed SemVer matching regex, that could match more version_groups than major.minor.patch and tested my changes against test-example Jens from Onwerk provided; 
