### PR TITLE
#257 - fix nugetParser; it should ignore unstable version when finding latest versions;

### DIFF
--- a/lib/versioneye/parsers/nuget_parser.rb
+++ b/lib/versioneye/parsers/nuget_parser.rb
@@ -75,6 +75,16 @@ class NugetParser < CommonParser
   def parse_requested_version(version_label, dependency, product)
     return dependency if product.nil?
 
+    version_label = cleanup_version version_label
+    
+    # Ignore cases like => "dev-master | ^1.0"
+    if version_label.match(/.+\|.+/).nil?
+      dependency[:stability] = VersionTagRecognizer.stability_tag_for version_label
+      VersionTagRecognizer.remove_minimum_stability version_label
+    else
+      dependency[:stability] = VersionTagRecognizer::A_STABILITY_STABLE
+    end
+
     latest_version = parse_version_data(version_label, product)
     return dependency if latest_version.nil?
 
@@ -110,27 +120,29 @@ class NugetParser < CommonParser
       version_data[:label] = '*'
     elsif ( m = rules[:exact].match(version) )
       res = VersionService.from_ranges(product.versions, m[:version])
-      version_data[:version] = res.last.version unless res.to_a.empty?
+      latest_version = VersionService.newest_version res
+      version_data[:version] = latest_version[:version] if latest_version
       version_data[:comperator] = '='
 
     elsif ( m = rules[:less_than].match(version) )
-      res = VersionService.smaller_than(product.versions, m[:version], true)
-      version_data[:version]    = res.last.version unless res.to_a.empty?
+      latest_version = VersionService.smaller_than(product.versions, m[:version])
+      version_data[:version]    = latest_version[:version] if latest_version
       version_data[:comperator] = '<'
 
     elsif ( m = rules[:less_equal].match(version) )
-      res = VersionService.smaller_than_or_equal(product.versions, m[:version], true)
-      version_data[:version]    =  res.last.version unless res.to_a.empty?
+      latest_version = VersionService.smaller_than_or_equal(product.versions, m[:version])
+      version_data[:version]    =  latest_version[:version] if latest_version
       version_data[:comperator] = '<='
 
     elsif ( m = rules[:greater_than].match(version) )
-      res = VersionService.greater_than(product.versions, m[:version], true)
-      version_data[:version]    = res.last.version unless res.to_a.empty?
+      latest_version = VersionService.greater_than(product.versions, m[:version])
+      version_data[:version]    = latest_version[:version] if latest_version
       version_data[:comperator] = '>'
 
     elsif ( m = rules[:greater_eq_than].match(version) )
-      res = VersionService.greater_than_or_equal(product.versions, m[:version], true)
-      version_data[:version]    = res.last.version unless res.to_a.empty?
+      latest_version = VersionService.greater_than_or_equal(product.versions, m[:version])
+     
+      version_data[:version] = latest_version[:version] if latest_version
       version_data[:comperator] = '>='
 
     elsif ( m = rules[:gt_range_lt].match(version) )
@@ -207,7 +219,7 @@ class NugetParser < CommonParser
     prod_name = node.attr("id").to_s.strip
     version_label = node.attr("version").to_s.strip
 
-    Projectdependency.new({
+    dep = Projectdependency.new({
       language: Product::A_LANGUAGE_CSHARP,
       name: prod_name,
       prod_key: prod_name,
@@ -216,6 +228,8 @@ class NugetParser < CommonParser
       target: target,
       scope: scope
     })
+    
+    dep
   end
 
 

--- a/spec/versioneye/parsers/nuget_parser_spec.rb
+++ b/spec/versioneye/parsers/nuget_parser_spec.rb
@@ -212,7 +212,7 @@ describe NugetParser do
 
     it "returns correct version for requested version 1.6" do
       version_data = parser.parse_version_data("1.6", product3)
-      
+    
       expect( version_data).not_to be_nil
       expect( version_data[:label] ).to eq("1.6")
       expect( version_data[:version] ).to eq("2.1")
@@ -422,6 +422,35 @@ describe NugetParser do
       expect(res[:version_requested]).to eq('24.12.0')
       expect(res[:version_label]).to eq('24.12.0')
       expect(res[:comperator]).to eq('>=')
+    end
+
+    it "doesnt mark outdated if latest product is not stable and version_label is fixed on latest stable" do
+      product4.version = '2.0' # it's latest stable version
+      product4.versions << FactoryGirl.build( :product_version, version: '2.1-alpha')
+
+      #none of those example should return alpha version
+      res = parser.parse_requested_version('2.0', depx, product4)
+      expect(res).not_to be_nil
+      expect(res[:version_requested]).to eq('2.0')
+      expect(res[:version_label]).to eq('2.0')
+      expect(res[:comperator]).to eq('>=')
+
+      res = parser.parse_requested_version('(1.9,)', depx, product4)
+      expect(res).not_to be_nil
+      expect(res[:version_requested]).to eq('2.0')
+      expect(res[:version_label]).to eq('(1.9,)')
+      expect(res[:comperator]).to eq('>')
+      
+    
+      res = parser.parse_requested_version('(,2.2)', depx, product4)
+      expect(res).not_to be_nil
+      expect(res[:version_requested]).to eq('2.0')
+      expect(res[:comperator]).to eq('<')
+
+      res = parser.parse_requested_version('(,2.2]', depx, product4)
+      expect(res).not_to be_nil
+      expect(res[:version_requested]).to eq('2.0')
+      expect(res[:comperator]).to eq('<=')
     end
   end
 end


### PR DESCRIPTION
I noticed that 1 of dependencies in the Onwerk's project in the Bitbucket issue #257 was marked outdated, but it should be green because it was fixed to latest stable version, but parser used latest and unstable version for comparison;


Old version took the latest version from the result list, but this list also included unstable versions;
I rewrite affected version_ranges to go through `VersionService.newest_version` so that filters out unstable versions now;
