### PR TITLE
40 add nuget packages parser

### DIFF
--- a/lib/versioneye/parsers/nuget_packages_parser.rb
+++ b/lib/versioneye/parsers/nuget_packages_parser.rb
@@ -47,8 +47,17 @@ class NugetPackagesParser < NugetParser
 
   def process_dependency(pkg_node)
     prod_name = pkg_node.attr('id').to_s.strip
-    version_label = pkg_node.attr('version').to_s.strip
+    version_requested = pkg_node.attr('version').to_s.strip
+    allowed_range = pkg_node.attr('allowedVersions').to_s.strip
     target = pkg_node.attr('targetFramework').to_s.strip
+
+    #by default packages.config fixes automatically version as x >= VERSION, 
+    # but allowedVersions allows humans defines acceptable versionRange as in a nuspec;
+    version_label = if allowed_range.empty?
+                      version_requested
+                    else
+                      allowed_range
+                    end
 
     Projectdependency.new({
       language: Product::A_LANGUAGE_CSHARP,

--- a/lib/versioneye/parsers/nuget_parser.rb
+++ b/lib/versioneye/parsers/nuget_parser.rb
@@ -120,6 +120,7 @@ class NugetParser < CommonParser
       newest = VersionService.newest_version(product.versions)
       version_data[:version] = newest.version if newest
       version_data[:label] = '*'
+
     elsif ( m = rules[:exact].match(version) )
       res = VersionService.from_ranges(product.versions, m[:version])
       latest_version = VersionService.newest_version res
@@ -190,6 +191,10 @@ class NugetParser < CommonParser
     end
 
     version_data
+  rescue Exception => e
+    log.error "NugetParser.parse_version_data: Failed to find match for version label #{version} for #{product.prod_id}"
+    log.error e.backtrace.inspect
+    return nil
   end
 
   def parse_dependencies(doc)

--- a/spec/fixtures/files/nuget/onwerk_packages.config
+++ b/spec/fixtures/files/nuget/onwerk_packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CsQuery" version="1.3.4" targetFramework="net40" />
+  <package id="CsQuery" version="1.3.4" targetFramework="net40" allowedVersions="[1.3.4]"/>
   <package id="BuildTools.StyleCop" version="4.7.49.0" targetFramework="net40" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net40" />
   <package id="Onwerk.Mailer" version="1.6.6.0" targetFramework="net40" />

--- a/spec/versioneye/parsers/nuget_packages_parser_spec.rb
+++ b/spec/versioneye/parsers/nuget_packages_parser_spec.rb
@@ -104,6 +104,13 @@ describe NugetPackagesParser do
 
   context "onwerk's failed project" do
     it "parses their packages.config correctly" do
+      product3.versions << FactoryGirl.build(:product_version, version: '1.3.4')
+      product3.versions << FactoryGirl.build(:product_version, version: '1.4.0')
+
+      product7.versions << FactoryGirl.build(:product_version, version: '0.18.2')
+      product7.versions << FactoryGirl.build(:product_version, version: '0.18.3.1')
+      
+      
       project = parser.parse_content(onwerk_file, "ftp://spec_test")
       expect(project).not_to be_nil
       expect(project.projectdependencies.size).to eq(5)
@@ -111,6 +118,7 @@ describe NugetPackagesParser do
       deps = project.projectdependencies
 
       expect( deps[0].name ).to eq(product3[:name])
+      expect( deps[0].version_label ).to eq('[1.3.4]')
       expect( deps[0].version_requested ).to eq(product3[:version])
       expect( deps[0].comperator).to eq('=')
 
@@ -128,7 +136,7 @@ describe NugetPackagesParser do
 
       expect( deps[4].name ).to eq(product7[:name])
       expect( deps[4].version_requested ).to eq(product7[:version])
-      expect( deps[4].comperator).to eq('=')
+      expect( deps[4].comperator).to eq('>=')
 
     end
   end


### PR DESCRIPTION
I add support for the `allowedVersions` attribute for nuget_packages_parsers, which allows constraining version ranges for updates; more info here: [Constraining Upgrades To Allowed Versions](https://docs.nuget.org/create/versioning)