### PR TITLE
Fix: NugetJSONParser failed to parse files with Unicode whitespaces and non-width characters;

### DIFF
--- a/lib/versioneye/parsers/common_parser.rb
+++ b/lib/versioneye/parsers/common_parser.rb
@@ -13,11 +13,40 @@ class CommonParser
   end
 
   def from_json(json_doc)
+    json_doc = json_doc.force_encoding(Encoding::UTF_8).strip
+    json_doc = clean_spaces(json_doc) #replace non-ascii spaces with ascii spaces
     JSON.parse(json_doc, {symbolize_names: true})
   rescue => e
     log.error "from_json: failed to parse #{json_doc}"
     log.error e.backtrace.join('\n')
     return nil
+  end
+
+
+  SPECIAL_SPACES = [
+    0x00A0,                # NO-BREAK SPACE
+    0x1680,                # OGHAM SPACE MARK
+    0x180E,                # MONGOLIAN VOWEL SEPARATOR
+    (0x2000..0x200A).to_a, # EN QUAD..HAIR SPACE
+    0x2028,                # LINE SEPARATOR
+    0x2029,                # PARAGRAPH SEPARATOR
+    0x202F,                # NARROW NO-BREAK SPACE
+    0x205F,                # MEDIUM MATHEMATICAL SPACE
+    0x3000,                # IDEOGRAPHIC SPACE
+  ].flatten.collect{|e| [e].pack 'U*'}
+
+  ZERO_WIDTH = [
+    0x200B,                # ZERO WIDTH SPACE
+    0x200C,                # ZERO WIDTH NON-JOINER
+    0x200D,                # ZERO WIDTH JOINER
+    0x2060,                # WORD JOINER
+    0xFEFF,                # ZERO WIDTH NO-BREAK SPACE
+  ].flatten.collect{|e| [e].pack 'U*'}
+  
+  def clean_spaces(txt)
+    txt.gsub!(Regexp.new(ZERO_WIDTH.join("|")), "") 
+    txt.gsub!(Regexp.new(SPECIAL_SPACES.join("|") + "|\s"), " ")
+    txt
   end
 =begin
 

--- a/lib/versioneye/parsers/common_parser.rb
+++ b/lib/versioneye/parsers/common_parser.rb
@@ -13,14 +13,11 @@ class CommonParser
   end
 
   def from_json(json_doc)
-    doc = nil
-    begin
-      doc = JSON.parse(json_doc, {symbolize_names: true})
-    rescue
-      log.error "Failed to parse #{json_doc}"
-    end
-
-    doc
+    JSON.parse(json_doc, {symbolize_names: true})
+  rescue => e
+    log.error "from_json: failed to parse #{json_doc}"
+    log.error e.backtrace.join('\n')
+    return nil
   end
 =begin
 

--- a/lib/versioneye/parsers/nuget_json_parser.rb
+++ b/lib/versioneye/parsers/nuget_json_parser.rb
@@ -55,6 +55,4 @@ class NugetJsonParser < NugetParser
     end
     deps
   end
-
-
 end

--- a/spec/fixtures/files/nuget/igor_project.json
+++ b/spec/fixtures/files/nuget/igor_project.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "version": "1.0.0",
 
   "dependencies": {

--- a/spec/fixtures/files/nuget/igor_project.json
+++ b/spec/fixtures/files/nuget/igor_project.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0.0",
+
+  "dependencies": {
+    "NETStandard.Library": "1.6.0"
+  },
+
+  "frameworks": {
+    "netstandard1.6": {
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/spec/versioneye/parsers/nuget_json_parser_spec.rb
+++ b/spec/versioneye/parsers/nuget_json_parser_spec.rb
@@ -144,6 +144,11 @@ describe NugetJsonParser do
       )
     }
 
+		it "fails to parse IGORs doc without clean up" do
+			expect { JSON.parse(igor_project_file) }.to raise_error(JSON::ParserError)
+			expect { JSON.parse(parser.clean_spaces(igor_project_file)) }.not_to raise_error(JSON::ParserError)
+		end
+
     it "parses project that a client failed to analyze" do
       project = parser.parse_content igor_project_file, "ftp://spec/dir/"
       expect( project ).not_to be nil

--- a/spec/versioneye/parsers/nuget_json_parser_spec.rb
+++ b/spec/versioneye/parsers/nuget_json_parser_spec.rb
@@ -129,8 +129,30 @@ describe NugetJsonParser do
       expect( deps[2].name ).to eq(product6[:name])
       expect( deps[2].version_requested ).to eq(product6[:version])
       expect( deps[2].comperator ).to eq("=")
-
       
+    end
+
+    let(:igor_project_file){ File.read "spec/fixtures/files/nuget/igor_project.json"  }
+    let(:product10){
+      FactoryGirl.create(
+        :product_with_versions,
+        prod_key: "NETStandard.Library",
+        name: "NETStandard.Library",
+        prod_type: Project::A_TYPE_NUGET,
+        language: Product::A_LANGUAGE_CSHARP,
+        version: "1.6.0"
+      )
+    }
+
+    it "parses project that a client failed to analyze" do
+      project = parser.parse_content igor_project_file, "ftp://spec/dir/"
+      expect( project ).not_to be nil
+      expect( project.projectdependencies.size ).to eq(1)
+
+      deps = project.projectdependencies
+      expect( deps[0].name ).to eq(product10[:name])
+      expect( deps[0].version_requested ).to eq(product10[:version])
+      expect( deps[0].comperator ).to eq('=')
     end
   end
 


### PR DESCRIPTION
One of our user tried to parse he's [project.json](https://raw.githubusercontent.com/another-guy/ObEq/master/ObEq/project.json), but it kept showing parsing failures even JSONLinter showed it's totally valid doc.

Issue was that it included [U+FEFF](http://www.fileformat.info/info/unicode/char/feff/index.htm) character at the beginning JSON file;

I added additional helper function `clean_spaces` for the `CommonParser`, which now removes all the non-width characters and replaces various unicode spaces with ASCII space.

original issue: https://bitbucket.org/versioneye/versioneye/issues/263/issues-with-parsing-projectjson-in-net
