### PR TITLE
#42 - switch packages.config parser from upgrade comperator to install

### DIFF
--- a/lib/versioneye/parsers/nuget_packages_parser.rb
+++ b/lib/versioneye/parsers/nuget_packages_parser.rb
@@ -51,12 +51,10 @@ class NugetPackagesParser < NugetParser
     allowed_range = pkg_node.attr('allowedVersions').to_s.strip
     target = pkg_node.attr('targetFramework').to_s.strip
 
-    #by default packages.config fixes automatically version as x >= VERSION, 
-    # but allowedVersions allows humans defines acceptable versionRange as in a nuspec;
     version_label = if allowed_range.empty?
-                      version_requested
+                      '[' + version_requested.to_s + ']' #nuget install pulls only fixed versions; and [x] matches with Nuget comperator;
                     else
-                      allowed_range
+                      allowed_range #it's already using Nuget version ranges
                     end
 
     Projectdependency.new({
@@ -64,7 +62,7 @@ class NugetPackagesParser < NugetParser
       name: prod_name,
       prod_key: prod_name,
       version_label: version_label,
-      version_requested: version_label,
+      version_requested: version_requested, #will be updated by parse_requested_version
       target: target
     })
   end

--- a/spec/versioneye/parsers/nuget_packages_parser_spec.rb
+++ b/spec/versioneye/parsers/nuget_packages_parser_spec.rb
@@ -41,11 +41,11 @@ describe NugetPackagesParser do
       deps = project.projectdependencies
       
       expect( deps[0].name ).to eq(product1[:name])
-      expect( deps[0].version_requested ).to eq(product1[:version])
+      expect( deps[0].version_requested ).to eq( product1[:version] )
       expect( deps[0].comperator).to eq('=')
 
       expect( deps[1].name ).to eq(product2[:name])
-      expect( deps[1].version_requested ).to eq(product2[:version])
+      expect( deps[1].version_requested ).to eq( product2[:version] )
       expect( deps[1].comperator).to eq('=')
     end
   end
@@ -136,7 +136,7 @@ describe NugetPackagesParser do
 
       expect( deps[4].name ).to eq(product7[:name])
       expect( deps[4].version_requested ).to eq(product7[:version])
-      expect( deps[4].comperator).to eq('>=')
+      expect( deps[4].comperator).to eq('=')
 
     end
   end


### PR DESCRIPTION
Hi,

by default the parser for `packages.config` used version comparator used during packages upgrade, but `nuget install` fetches only fixed versions;

I add simple workaround that transforms a version_label to the nuget version range used for install;

Upgrade range is too broad and VersionEye loses utility as tool to check outdated packages as all the packages will be in the range of update;
