### PR TITLE
Fix #51 Gemfile parser resolves wrong version with platforms array

### DIFF
--- a/lib/versioneye/parsers/gemfile_parser.rb
+++ b/lib/versioneye/parsers/gemfile_parser.rb
@@ -239,11 +239,11 @@ class GemfileParser < CommonParser
         version = element
         break
       else
-        version = element
+        version = element if gem_requirement?(element)
       end
     end
-    version = version.gsub('"', '')
-    version.gsub("'", "")
+
+    strip_quotes(version)
   end
 
 
@@ -313,5 +313,21 @@ class GemfileParser < CommonParser
     log.error e.backtrace.join("\n")
   end
 
+  private
+
+  def strip_quotes(version)
+    version = version.gsub('"', '')
+    version.gsub("'", '')
+  end
+
+  def gem_requirement?(requirement)
+    begin
+      requirement = strip_quotes(requirement)
+      Gem::Requirement.parse(requirement)
+      true
+    rescue Gem::Requirement::BadRequirementError
+      false
+    end
+  end
 
 end

--- a/spec/versioneye/parsers/gemfile_line_parser_spec.rb
+++ b/spec/versioneye/parsers/gemfile_line_parser_spec.rb
@@ -99,7 +99,7 @@ describe GemfileParser do
     it "returns correct version with multiple platforms" do
       line = "gem 'tzinfo-data', '= 3.0.3', platforms: [:mingw, :mswin, :x64_mingw, :mswin64]"
       elements = @parser.fetch_line_elements( line )
-      @parser.fetch_version( elements ).should eql("3.0.3")
+      @parser.fetch_version( elements ).should eql("= 3.0.3")
     end
 
     it "returns the right empty string because there is not version, only a group" do

--- a/spec/versioneye/parsers/gemfile_line_parser_spec.rb
+++ b/spec/versioneye/parsers/gemfile_line_parser_spec.rb
@@ -90,6 +90,18 @@ describe GemfileParser do
       @parser.fetch_version( elements ).should eql("")
     end
 
+    it "returns empty string with multiple platforms" do
+      line = "gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :mswin64]"
+      elements = @parser.fetch_line_elements( line )
+      @parser.fetch_version( elements ).should eql("")
+    end
+
+    it "returns correct version with multiple platforms" do
+      line = "gem 'tzinfo-data', '= 3.0.3', platforms: [:mingw, :mswin, :x64_mingw, :mswin64]"
+      elements = @parser.fetch_line_elements( line )
+      @parser.fetch_version( elements ).should eql("3.0.3")
+    end
+
     it "returns the right empty string because there is not version, only a group" do
       line = "gem 'rspec',     :group => [:test, :development]"
       elements = @parser.fetch_line_elements( line )


### PR DESCRIPTION
Uses the original requirement parser of Rubygems to make sure we are looking at a correct requirement.