### PR TITLE
Fix for the issue #17

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 
 # 20% performance boost for dalli. Doesn't work on Windows.
 gem 'kgio', '~> 2.10.0', platforms: :ruby
+gem 'cocoapods-core', git: 'https://github.com/timgluz/Core.git', branch: 'rails5'
 
 group :test do
   gem 'rack-test'       , '0.6.3'
@@ -13,7 +14,7 @@ group :test do
   gem 'rspec'           , '~> 3.5.0'
   gem 'rspec_junit_formatter', '0.2.3'
   gem 'database_cleaner', '~> 1.5.1'
-  gem 'factory_girl'    , '~> 4.7.0'
+  gem 'factory_girl'    , '>= 4.7', :require => false
   gem 'capybara'        , '~> 2.10.1'
   gem 'capybara-firebug', '~> 2.1.0'
   gem 'vcr'             , '3.0.3', :require => false

--- a/spec/fixtures/files/pod_file/example1/Podfile
+++ b/spec/fixtures/files/pod_file/example1/Podfile
@@ -3,7 +3,7 @@ platform :ios
 pod 'SSToolkit'
 pod 'AFNetworking', '>= 0.2.1'
 pod 'CocoaLumberjack', '~> 1.2.0'
-pod 'Objection', :head # 'bleeding edge'
+pod 'Objection', github: 'https://github.com/atomicobject/objection.git'
 pod 'JSONKit', '1.1.0'
 pod 'HipsterInBerlin'
 

--- a/spec/fixtures/files/pod_file/target_example1/Podfile
+++ b/spec/fixtures/files/pod_file/target_example1/Podfile
@@ -11,7 +11,7 @@ target :default do
 end
 
 target :lite do
-    link_with 'app-lite'
+    inherit! :search_paths
 
     pod 'TestFlightSDK', '>= 1.1'
     pod 'MBProgressHUD', '0.5'
@@ -23,7 +23,6 @@ target :lite do
 end
 
 target :demo do
-    link_with 'app-demo'
 
     pod 'TestFlightSDK', '>= 1.1'
     pod 'MBProgressHUD', '0.5'

--- a/spec/fixtures/files/pod_file/target_example2/Podfile
+++ b/spec/fixtures/files/pod_file/target_example2/Podfile
@@ -1,9 +1,7 @@
 platform :osx, '10.8'
 
-link_with ['Sail', 'Sail-Tests']
-
 pod 'SSKeychain', '~> 0.1.4'
-pod 'INAppStoreWindow', :head
+pod 'INAppStoreWindow', git: 'https://github.com/indragiek/INAppStoreWindow.git'
 pod 'AFNetworking', '1.1.0'
 pod 'Reachability', '~> 3.1.0'
 pod 'KSADNTwitterFormatter', '~> 0.1.0'

--- a/spec/fixtures/files/pod_file/target_example_3/Podfile
+++ b/spec/fixtures/files/pod_file/target_example_3/Podfile
@@ -4,6 +4,7 @@ target :debug do
     pod 'CocoaLumberjack'
 end
 
-target :test, :exclusive => true do
+target :test do
+    inherit! :search_paths
     pod 'Kiwi'
 end

--- a/versioneye-core.gemspec
+++ b/versioneye-core.gemspec
@@ -26,7 +26,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'httparty', '~> 0.14.0'
   s.add_runtime_dependency 'persistent_httparty', '~> 0.1.0'
   s.add_runtime_dependency 'nokogiri', '~> 1.6.8'
-  s.add_runtime_dependency 'cocoapods-core', '~> 0.39.0'
+  # TODO: comment out when official core will support activesupport5
+  # meanwhile it will use forked version defined in Gemfile
+  #  s.add_runtime_dependency 'cocoapods-core', '~> 1.1'
   s.add_runtime_dependency 'actionmailer', '~> 5.0.0.1'
   s.add_runtime_dependency 'pdfkit', '~> 0.8.2'
   s.add_runtime_dependency 'bunny', '~> 2.6.0'


### PR DESCRIPTION
PodspecParser was failing due the changes in the specifications - i just updated fixtures files associated to failed testcases. All tests related to PodspecParser are passing now;

All of this wasn't so simple - i was required to fork the [CocoaPods/Core](https://github.com/CocoaPods/Core) project as all of its releases use `activesupport > 3, < 5`, which runned into conflicts with the dependencies in `versioneye-core`. 
My fork just includes `activesupport > 5` and requires  `Ruby > 2.3.1`

ps: this upgrade breaks compability with older `podspecs < 1.0`