### PR TITLE
fix for #53 - remove platform extensions from version;

### DIFF
--- a/lib/versioneye/parsers/gemfile_parser.rb
+++ b/lib/versioneye/parsers/gemfile_parser.rb
@@ -243,7 +243,9 @@ class GemfileParser < CommonParser
       end
     end
 
-    strip_quotes(version)
+    #removes -x64,-x86, -mingw32 etc from version id
+    version = strip_quotes(version)
+    strip_platform_exts(version)
   end
 
 
@@ -311,6 +313,21 @@ class GemfileParser < CommonParser
   rescue => e
     log.error e.message
     log.error e.backtrace.join("\n")
+  end
+
+  def strip_platform_exts(version)
+    blacklist = Set.new ['x86', 'x64', 'java', 'mingw32'] #from nokogiri versions
+    tokens = version.to_s.split('-')
+    tokens = tokens.reduce([]) do |acc, tkn|
+      unless blacklist.include? tkn.downcase
+        #only add tokens that arenot in the blacklist
+        acc << tkn
+      end
+
+      acc
+    end
+
+    tokens.join('-')
   end
 
   private

--- a/lib/versioneye/parsers/gemfilelock_parser.rb
+++ b/lib/versioneye/parsers/gemfilelock_parser.rb
@@ -49,6 +49,10 @@ class GemfilelockParser < GemfileParser
 
       version_match = row[1]
       version = version_match.gsub('(', '').gsub(')', '')
+      
+      #removes -x64,-x86, -mingw32 etc from version id
+      version = strip_platform_exts(version)
+
       dependency = Projectdependency.new
 
       product = fetch_product_for row[0]


### PR DESCRIPTION
Hi,

i added extra helper function for GemfileParser, which removes platform extensions from the version names;

For example nokogiri doesnt respect semantic versioning and uses `-` separator to add additional build information, instead of `+`; I took list of platform tags from their releases and the `strip_platform_exts` function removes all the matching tags from the version label;

I added testcases to proof correctness of helper function and to check correct behaviour after parsing;