### PR TITLE
58 fix nuget parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ versioneye.sublime-workspace
 rspec.xml
 scripts/set_vars_for_dev_reiz.sh
 Gemfile.lock
+data/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,9 @@ mongodb:
   restart: always
   ports:
    - "27017:27017"
-  # volumes:
-  #  - /mnt/mongodb:/data
+  volumes:
+    - /Users/timgluz/workspace/versioneye/versioneye-core/data:/dumps
+    - /Users/timgluz/workspace/versioneye/versioneye-core/tmp/veye_dev:/data
 
 # AMQ Message Server
 rabbitmq:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,8 @@ mongodb:
   restart: always
   ports:
    - "27017:27017"
-  volumes:
-    - /Users/timgluz/workspace/versioneye/versioneye-core/data:/dumps
-    - /Users/timgluz/workspace/versioneye/versioneye-core/tmp/veye_dev:/data
+  #volumes:
+  #  - /mnt/mongodb:/data
 
 # AMQ Message Server
 rabbitmq:

--- a/lib/versioneye/parsers/nuget_packages_parser.rb
+++ b/lib/versioneye/parsers/nuget_packages_parser.rb
@@ -52,7 +52,8 @@ class NugetPackagesParser < NugetParser
     target = pkg_node.attr('targetFramework').to_s.strip
 
     version_label = if allowed_range.empty?
-                      '[' + version_requested.to_s + ']' #nuget install pulls only fixed versions; and [x] matches with Nuget comperator;
+                      #nuget install pulls only fixed versions; and [x] matches with Nuget comperator;
+                      '[' + version_requested.to_s.strip + ']' 
                     else
                       allowed_range #it's already using Nuget version ranges
                     end

--- a/spec/fixtures/files/nuget/packages_issue58.config
+++ b/spec/fixtures/files/nuget/packages_issue58.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="xunit" version="2.2.0-beta3-build3402" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.2.0-beta3-build1187" targetFramework="net45" developmentDependency="true" />
+</packages>

--- a/spec/versioneye/parsers/nuget_parser_spec.rb
+++ b/spec/versioneye/parsers/nuget_parser_spec.rb
@@ -92,6 +92,7 @@ describe NugetParser do
       expect( exact.match("[1.0]") ).not_to be_nil
       expect( exact.match("[2.0.1]") ).not_to be_nil
       expect( exact.match("[2.0.1,]") ).not_to be_nil
+      expect( exact.match("[2.2.0-beta3-build1187]" )).not_to be_nil
     end
 
     it "matches rule of greater_than" do

--- a/versioneye-core.gemspec
+++ b/versioneye-core.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['LICENSE.txt', 'README.md']
   s.files            = `git ls-files -z`.split("\0")
 
-  s.add_runtime_dependency 'bundler', '~> 1.13.7'
+  s.add_runtime_dependency 'bundler', '~> 1.14'
   s.add_runtime_dependency 'naturalsorter', '~> 3.0.15'
   s.add_runtime_dependency 'dalli', '~> 2.7.6'
   s.add_runtime_dependency 'oauth', '~> 0.5.0'


### PR DESCRIPTION
The Bug was quite simple - it didnt used full version string for filtering, just only numerical part of it; and caused to look up stable versions after `2.2.0` when the latest stable version was `2.1.0` and all the  versions with `2.2.0` tag were pre-builds.