### PR TITLE
Fix for issue #62 - nuget parser cant find exact match when version_label is naughty

### DIFF
--- a/lib/versioneye/parsers/nuget_parser.rb
+++ b/lib/versioneye/parsers/nuget_parser.rb
@@ -178,7 +178,9 @@ class NugetParser < CommonParser
       version_data[:label] = '*'
 
     elsif ( m = rules[:exact].match(version) )
-      res = VersionService.from_ranges(product.versions, m[:semver])
+      lbl = m[:semver].to_s.strip
+      possible_formats = [lbl, normalize_version(lbl), pad_zeros(lbl), (lbl + '.0')] 
+      res = VersionService.versions_by_whitelist(product.versions, possible_formats)
       latest_version = VersionService.newest_version res
 
       version_data[:version] = latest_version[:version] if latest_version

--- a/lib/versioneye/parsers/nuget_parser.rb
+++ b/lib/versioneye/parsers/nuget_parser.rb
@@ -46,6 +46,63 @@ class NugetParser < CommonParser
     }
   end
 
+  # removes leading zeros and excess 0 after patch part
+  #breaking changes from 3.4 
+  #details: https://docs.microsoft.com/en-us/nuget/create-packages/dependency-versions
+  def normalize_version(version_label)
+    version, metadata, separator = split_version( version_label )
+
+    # remove spaces in the label
+    version = version.gsub(/\s/, '')
+    #replace leading zeros in version number
+    version = version.gsub(/\b0+(\d+)\b/, '\1')
+    # remove leading 0 if version has 4part: 1.1.1.0 -> 1.1.1
+    if version.match /^\d+(\.\d+){2,2}\.0+/
+      rpos = version.rindex('.') - 1
+      version = version[0..rpos]
+    end
+
+    lbl = version.to_s.strip
+    lbl += (separator.to_s + metadata) unless metadata.to_s.empty?
+
+    lbl
+  end
+
+  # adds missing minor, patch part as 0
+  def pad_zeros(version_label)
+    version, metadata, separator = split_version( version_label )
+
+    padded_version = case (version + ' ') #hack to make negation to work
+                     when /^\d+(?!\.)/ then version + '.0.0'
+                     when /^\d+\.\d+(?!\.)/ then version + '.0'
+                     else version
+                     end
+
+    padded_version += (separator.to_s + metadata) unless metadata.to_s.empty?
+    padded_version
+  end
+
+  # separates version from metadata, so we could manipulate version without changing metadata
+  # returns:
+  #   [version, metadata, separator] - separator is earliest build (+) or prerelease (-) separator
+  def split_version(version_label)
+    version_label = version_label.to_s.strip
+
+    build_start = version_label.index('+').to_i
+    prerelease_start = version_label.index('-').to_i
+
+    #-- split version so metadata would stay untouched
+    separator = if build_start == 0 and prerelease_start == 0
+                  '--' #shouldnt exist, so it doesnt split string
+                elsif prerelease_start == 0 or (build_start != 0 and build_start < prerelease_start )
+                  '+'
+                elsif build_start == 0 or (prerelease_start != 0 and prerelease_start < build_start)
+                  '-'
+                end
+    version, _, metadata = version_label.partition separator
+    [version, metadata, separator]
+  end
+
   def parse( url )
     response_body = fetch_response_body(url)
     if response_body.nil?

--- a/spec/fixtures/files/nuget/issue62.nuspec
+++ b/spec/fixtures/files/nuget/issue62.nuspec
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>Microsoft.AspNet.SignalR.Client</id>
+    <title>Microsoft ASP.NET SignalR .NET Client</title>
+    <version>__SIGNALR_PACKAGE_VERSION__</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>__SIGNALR_CLIENT_LICENSE_URL__</licenseUrl>
+    <copyright>__SIGNALR_COPYRIGHT_NOTICE__</copyright>
+    <projectUrl>http://www.asp.net/signalr</projectUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>.NET client for ASP.NET SignalR.</description>
+    <language>en-US</language>
+    <tags>Microsoft AspNet SignalR AspNetSignalR Client</tags>
+    <releaseNotes>https://github.com/SignalR/SignalR/releases</releaseNotes>
+    <dependencies>
+      <group targetFramework="net40">
+        <dependency id="CommonServiceLocator" version="[1.3]" />
+        <dependency id="Newtonsoft.Json" version="[5.0.0]" />
+        <dependency id="Microsoft.Web.Infrastructure" version="[1.0.0.0]" />
+      </group>
+  </metadata>
+  <files>
+    <file src="Net40\Microsoft.AspNet.SignalR.Client.dll" target="lib\net40" />
+    <file src="Net40\Microsoft.AspNet.SignalR.Client.xml" target="lib\net40" />
+    <file src="Net45\Microsoft.AspNet.SignalR.Client.dll" target="lib\net45" />
+    <file src="Net45\Microsoft.AspNet.SignalR.Client.xml" target="lib\net45" />
+    <file src="portable-net45+sl5+netcore45+wp8\Microsoft.AspNet.SignalR.Client.dll" target="lib\portable-net45+sl5+netcore45+wp8" />
+    <file src="portable-net45+sl5+netcore45+wp8\Microsoft.AspNet.SignalR.Client.xml" target="lib\portable-net45+sl5+netcore45+wp8" />
+  </files>
+</package>


### PR DESCRIPTION
It can now handle cases when version_label is not normalized in  the project file or database version has some additional zeroes in the minor or patch versions;