### PR TITLE
Add parser for npm-shrinkwrap.json file

### DIFF
--- a/lib/versioneye/models/projectdependency.rb
+++ b/lib/versioneye/models/projectdependency.rb
@@ -26,6 +26,8 @@ class Projectdependency < Versioneye::Model
   field :release          , type: Boolean
   field :stability        , type: String, :default => VersionTagRecognizer::A_STABILITY_STABLE
   field :transitive       , type: Boolean, :default => false
+  field :parent_id, type: BSON::ObjectId # refers parent project parent id
+
   # deepness in the transitive hirarchie. Direct dependencies are deepness 0.
   field :deepness         , type: Integer, :default => 0
 

--- a/lib/versioneye/parsers/godep_parser.rb
+++ b/lib/versioneye/parsers/godep_parser.rb
@@ -34,6 +34,19 @@ class GodepParser < PackageParser
     nil
   end
 
+  #extracts project ids for crawler
+  def extract_product_ids(content)
+    raise "GodepParser.parse_content: empty document" if content.to_s.empty?
+
+    godeps_doc = from_json content #replaces unicode spaces and returns symbolized doc
+    raise "GodepParser.parse_content: failed to parse #{content}" if godeps_doc.nil?
+
+    godeps_doc[:Deps].to_a.reduce([]) do |acc, dep|
+      acc << dep[:ImportPath]
+      acc
+    end
+  end
+
   def parse_dependencies(project, deps)
     return project if deps.to_a.empty?
 
@@ -82,7 +95,7 @@ class GodepParser < PackageParser
     # use version semver+sha<> if possible other wise just use SHA
     dependency[:version_requested] = (version_db[:version] ||  version_label ) #SEMVER_FROM_DB or SHA
     dependency[:version_label] = ( dep_comment || version_label ) #TAG or SHA
-   
+
     dependency
   end
 

--- a/lib/versioneye/parsers/package_parser.rb
+++ b/lib/versioneye/parsers/package_parser.rb
@@ -290,9 +290,9 @@ class PackageParser < CommonParser
     project = Project.new
     project.project_type = Project::A_TYPE_NPM
     project.language     = Product::A_LANGUAGE_NODEJS
-    project.name         = data['name']
-    project.description  = data['description']
-    project.version      = data['version']
+    project.name         = data[:name]
+    project.description  = data[:description]
+    project.version      = data[:version]
     project
   end
 
@@ -317,5 +317,13 @@ class PackageParser < CommonParser
     version
   end
 
+  def parse_json_safely(json_txt, keywordize =  true)
+    json_txt = json_txt.to_s.strip
+    return nil if json_txt.nil?
 
+    JSON.parse(json_txt, symbolize_names: (keywordize == true) )
+  rescue
+    logger.error "parse_json_safely: failed to parse json text: `#{json_txt}`"
+    nil
+  end
 end

--- a/lib/versioneye/parsers/parser_strategy.rb
+++ b/lib/versioneye/parsers/parser_strategy.rb
@@ -28,6 +28,8 @@ class ParserStrategy
       when Project::A_TYPE_NPM
         if url.match(/yarn\.lock/i)
           return YarnParser.new
+        elsif url.match(/npm-shrinkwrap\.json\z/i)
+          return ShrinkwrapParser.new
         else
           return PackageParser.new
         end

--- a/lib/versioneye/parsers/shrinkwrap_parser.rb
+++ b/lib/versioneye/parsers/shrinkwrap_parser.rb
@@ -1,0 +1,76 @@
+class ShrinkwrapParser < PackageParser
+  A_MAX_DEPTH = 32
+
+  def parse_content(content, token = nil)
+    content = content.to_s.strip
+    return nil if content.empty?
+    return nil if (content =~ /Not\s+found/i)
+
+    proj_doc = parse_json_safely content
+    return nil if proj_doc.nil?
+
+    project = init_project({
+      name: proj_doc[:name],
+      version: proj_doc[:version],
+      description: "npm-shrinkwrap.json"
+    })
+
+    parse_dependency_items proj_doc, project
+    project
+  end
+
+  def parse_dependency_items(proj_doc, project)
+    proj_doc[:dependencies].to_a.each do |dep_id, dep_doc|
+      parse_dependency(dep_id, dep_doc, project)
+    end
+
+    project
+  end
+
+  def parse_dependency(dep_id, dep_doc, project, depth = 0, parent_id = nil)
+    return nil if depth > A_MAX_DEPTH
+
+    product = Product.where(
+      language: Product::A_LANGUAGE_NODEJS,
+      prod_type: Project::A_TYPE_NPM,
+      prod_key: dep_id
+    ).first
+
+    #process dependency data and update project details
+    dep_db = init_dependency(product, dep_id, dep_doc, depth, parent_id)
+    parse_requested_version dep_db[:version_requested], dep_db, product
+    project.dep_number     += 1
+    project.out_number     += 1 if ProjectdependencyService.outdated?( dep_db )
+    project.unknown_number += 1 if product.nil?
+    project.projectdependencies.push dep_db
+
+    #process subdependencies
+    dep_doc[:dependencies].to_a.each do |sub_dep_id, sub_dep_doc|
+      parse_dependency(sub_dep_id, sub_dep_doc, project, depth + 1, dep_db.id)
+    end
+
+    project
+  end
+
+  def init_dependency(product, dep_id, dep_doc, depth = 0, parent_id = nil)
+    version_label = dep_doc[:from].to_s.split('@').last
+    dep = Projectdependency.new({
+      parent_id: parent_id,
+      language: Product::A_LANGUAGE_NODEJS,
+      name: dep_id,
+      prod_key: dep_id,
+      comperator: '=',
+      version_label: version_label,
+      version_requested: dep_doc[:version],
+      transitive: (depth > 0),
+      deepness: depth,
+      scope: Dependency::A_SCOPE_COMPILE
+    })
+
+    if product
+      dep[:version_current] = product[:version]
+    end
+
+    dep
+  end
+end

--- a/lib/versioneye/service.rb
+++ b/lib/versioneye/service.rb
@@ -104,6 +104,7 @@ module Versioneye
     require 'versioneye/parsers/cpan_parser'
     require 'versioneye/parsers/gemspec_parser'
     require 'versioneye/parsers/yarn_parser'
+    require 'versioneye/parsers/shrinkwrap_parser'
 
     require 'versioneye/updaters/update_strategy'
     require 'versioneye/updaters/common_updater'

--- a/lib/versioneye/services/project_import_service.rb
+++ b/lib/versioneye/services/project_import_service.rb
@@ -7,7 +7,7 @@ class ProjectImportService < Versioneye::Service
 
   def self.import_all_github user, orga_id, pfs = [
     'Gemfile', 'Gemfile.lock', '.gemspec', 'package.json', 'pom.xml', 'bower.json',
-    'Podfile', 'Podfile.lock', '.gradle', 'yarn.lock'
+    'Podfile', 'Podfile.lock', '.gradle', 'yarn.lock', 'npm-shrinkwrap.json'
     ], max_depth = 2
     user.github_repos.where(:fullname => /\Ablinkist/, :private => true).each do |repo|
       if repo.branches.to_a.empty?

--- a/lib/versioneye/services/project_service.rb
+++ b/lib/versioneye/services/project_service.rb
@@ -18,7 +18,13 @@ class ProjectService < Versioneye::Service
     return Project::A_TYPE_RUBYGEMS  if (!(/Gemfile\z/ =~ trimmed_name).nil?)        or (!(/Gemfile.lock\z/  =~ trimmed_name).nil?) or (/\w\.gemspec\z/ =~ trimmed_name)
     return Project::A_TYPE_COMPOSER  if (!(/composer.json\z/ =~ trimmed_name).nil?)  or (!(/composer.lock\z/ =~ trimmed_name).nil?)
     return Project::A_TYPE_PIP       if (!(/requirements.txt\z/ =~ trimmed_name).nil?) or (!(/requirements\/.+\.txt/i =~ trimmed_name).nil?) or (!(/setup.py\z/ =~ trimmed_name).nil?) or (!(/pip.log\z/ =~ trimmed_name).nil?)
-    return Project::A_TYPE_NPM       if (!(/package.json\z/ =~ trimmed_name).nil? or !(/yarn\.lock\z/i =~ trimmed_name).nil? )
+
+    if (!(/package.json\z/ =~ trimmed_name).nil? \
+        or !(/yarn\.lock\z/i =~ trimmed_name).nil? \
+        or !(/npm-shrinkwrap\.json\z/i =~ trimmed_name).nil?)
+      return Project::A_TYPE_NPM
+    end
+
     return Project::A_TYPE_GRADLE    if (!(/.gradle\z/ =~ trimmed_name).nil?)
     return Project::A_TYPE_SBT       if (!(/.sbt\z/ =~ trimmed_name).nil?)
     return Project::A_TYPE_MAVEN2    if (!(/pom.xml\z/ =~ trimmed_name).nil?) or (!(/.pom\z/ =~ trimmed_name).nil?) or (!(/external_dependencies.xml\z/ =~ trimmed_name).nil?) or (!(/external-dependencies.xml\z/ =~ trimmed_name).nil?) or (!(/pom.json\z/ =~ trimmed_name).nil?)

--- a/spec/fixtures/files/npm-shrinkwrap.json
+++ b/spec/fixtures/files/npm-shrinkwrap.json
@@ -1,0 +1,44 @@
+{
+  "name": "baconsnake",
+  "version": "0.1.0",
+  "dependencies": {
+    "bower": {
+      "version": "1.4.1",
+      "from": "bower@>=1.0.0 <2.0.0",
+      "dependencies": {
+        "archy": {
+          "version": "1.0.0",
+          "from": "archy@1.0.0"
+        },
+        "bower-config": {
+          "version": "0.6.1",
+          "from": "bower-config@>=0.6.1 <0.7.0",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0"
+            },
+            "mout": {
+              "version": "0.9.1",
+              "from": "mout@>=0.9.0 <0.10.0"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.0 <0.7.0",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/versioneye/parsers/godep_parser_spec.rb
+++ b/spec/versioneye/parsers/godep_parser_spec.rb
@@ -4,7 +4,7 @@ describe GodepParser do
   let(:test_file_url){}
   let(:test_file){ File.read("spec/fixtures/files/godep/Godeps.json") }
   let(:parser){ GodepParser.new }
-    
+
   let(:shax){ '0d7f52660096c5a22f2cb95c102e0693f773a593' }
   let(:product1_sha){ "0754dfcca172cfc4c07a61c123b23e5127d26760" }
 
@@ -50,6 +50,19 @@ describe GodepParser do
       version: "0.2.0"
     )
   }
+
+  context "extract_product_ids" do
+    it "returns correct product ids for spec file" do
+      res = parser.extract_product_ids test_file
+      expect(res).not_to be nil
+      expect(res.size).to eq(4)
+      expect(res[0]).to eq('github.com/OpenBazaar/go-blockstackclient')
+      expect(res[1]).to eq('github.com/btcsuite/btcd/blockchain')
+      expect(res[2]).to eq('github.com/btcsuite/seelog')
+      expect(res[3]).to eq('github.com/fatih/color')
+    end
+  end
+
 
   context "parse_requested_version" do
     let(:dep_empty){
@@ -101,7 +114,7 @@ describe GodepParser do
       expect( dep[:version_label] ).to eq(shax)
       expect( dep[:version_requested] ).to eq('1.6')
       expect( dep[:version_current] ).to eq(product2[:version])
-      expect( dep[:outdated] ).to be_nil 
+      expect( dep[:outdated] ).to be_nil
     end
 
     it "returns dependency that uses semver matching with Comment tag on the line" do
@@ -120,7 +133,7 @@ describe GodepParser do
   end
 
   context "parse_content" do
-    let(:product2_tag){ 'BTCD_0_12_0_BETA-88-g0d7f526' }    
+    let(:product2_tag){ 'BTCD_0_12_0_BETA-88-g0d7f526' }
 
     before do
       product1.versions << FactoryGirl.build(
@@ -174,21 +187,21 @@ describe GodepParser do
       expect( deps[1].version_requested ).to eq( '1.6' )
       expect( deps[1].version_current ).to eq(product2[:version] )
       expect( deps[1].outdated ).to be_truthy
-    
+
       expect( deps[2].name ).to eq(product3[:name] )
       expect( deps[2].prod_key ).to eq(product3[:prod_key])
       expect( deps[2].version_label ).to eq( "v2.1-84-g313961b" )
       expect( deps[2].version_requested ).to eq( "313961b101eb55f65ae0f03ddd4e322731763b6c" )
       expect( deps[2].version_current ).to eq('0.0.0+NA')
       expect( deps[2].outdated ).to be_falsey
-      
+
       expect( deps[3].name ).to eq(product4[:name] )
       expect( deps[3].prod_key ).to eq(product4[:prod_key])
       expect( deps[3].version_label ).to eq( "v0.2.0" )
       expect( deps[3].version_requested ).to eq( '0.2.0' )
       expect( deps[3].version_current ).to eq('0.2.0')
       expect( deps[3].outdated ).to be_falsey
-    
+
     end
   end
 end

--- a/spec/versioneye/parsers/parser_strategy_spec.rb
+++ b/spec/versioneye/parsers/parser_strategy_spec.rb
@@ -110,6 +110,11 @@ describe ParserStrategy do
       expect( parser.is_a?(YarnParser) ).to be_truthy
     end
 
+    it "returns ShrinkwrapParser" do
+      parser = ParserStrategy.parser_for(Project::A_TYPE_NPM, 'npm-shrinkwrap.json')
+      expect( parser.is_a?(ShrinkwrapParser) ).to be_truthy
+    end
+
     it "returns nil" do
       parser = ParserStrategy.parser_for( "HujBuy", "lein" )
       expect( parser ).to be_nil

--- a/spec/versioneye/parsers/shrinkwrap_parser_spec.rb
+++ b/spec/versioneye/parsers/shrinkwrap_parser_spec.rb
@@ -1,0 +1,182 @@
+require 'spec_helper'
+
+describe ShrinkwrapParser do
+  let(:parser){ ShrinkwrapParser.new }
+  let(:test_file){ File.read 'spec/fixtures/files/npm-shrinkwrap.json' }
+
+  let(:product1){
+    FactoryGirl.create(
+      :product_with_versions,
+      name: 'bower',
+      prod_key: 'bower',
+      prod_type: Project::A_TYPE_NPM,
+      language: Product::A_LANGUAGE_NODEJS,
+      version: '1.4.1'
+    )
+  }
+
+  let(:product2){
+    FactoryGirl.create(
+      :product_with_versions,
+      name: 'archy',
+      prod_key: 'archy',
+      prod_type: Project::A_TYPE_NPM,
+      language: Product::A_LANGUAGE_NODEJS,
+      version: '1.0.0'
+    )
+  }
+
+  let(:product3){
+    FactoryGirl.create(
+      :product_with_versions,
+      name: 'bower-config',
+      prod_key: 'bower-config',
+      prod_type: Project::A_TYPE_NPM,
+      language: Product::A_LANGUAGE_NODEJS,
+      version: '0.6.1'
+    )
+  }
+
+  let(:product4){
+    FactoryGirl.create(
+      :product_with_versions,
+      name: 'graceful-fs',
+      prod_key: 'graceful-fs',
+      prod_type: Project::A_TYPE_NPM,
+      language: Product::A_LANGUAGE_NODEJS,
+      version: '2.0.3'
+    )
+  }
+
+  let(:product5){
+    FactoryGirl.create(
+      :product_with_versions,
+      name: 'mout',
+      prod_key: 'mout',
+      prod_type: Project::A_TYPE_NPM,
+      language: Product::A_LANGUAGE_NODEJS,
+      version: '0.9.1'
+    )
+  }
+
+  let(:product6){
+    FactoryGirl.create(
+      :product_with_versions,
+      name: 'optimist',
+      prod_key: 'optimist',
+      prod_type: Project::A_TYPE_NPM,
+      language: Product::A_LANGUAGE_NODEJS,
+      version: '0.6.1'
+    )
+  }
+
+  let(:product7){
+    FactoryGirl.create(
+      :product_with_versions,
+      name: 'wordwrap',
+      prod_key: 'wordwrap',
+      prod_type: Project::A_TYPE_NPM,
+      language: Product::A_LANGUAGE_NODEJS,
+      version: '0.0.3'
+    )
+  }
+
+  let(:product8){
+    FactoryGirl.create(
+      :product_with_versions,
+      name: 'minimist',
+      prod_key: 'minimist',
+      prod_type: Project::A_TYPE_NPM,
+      language: Product::A_LANGUAGE_NODEJS,
+      version: '0.1.0'
+    )
+  }
+
+  context "parse_content" do
+    before do
+      product1.save
+      product2.save
+      product3.save
+      product4.save
+      product5.save
+      product6.save
+      product7.save
+      product8.save
+      product8.versions << FactoryGirl.build(:product_version, version: '0.0.10')
+      product8.versions << FactoryGirl.build(:product_version, version: '0.1.0')
+    end
+
+    it "parses project file correctly" do
+      proj = parser.parse_content test_file
+      expect(proj).not_to be_nil
+      expect(proj[:name]).to eq('baconsnake')
+      expect(proj[:version]).to eq('0.1.0')
+      expect(proj.dep_number).to eq(8)
+
+      dep = proj.dependencies[0]
+      expect(dep[:name]).to eq(product1[:name])
+      expect(dep[:version_requested]).to eq(product1[:version])
+      expect(dep[:version_current]).to eq(product1[:version])
+      expect(dep[:outdated]).to be_falsey
+      expect(dep[:transitive]).to be_falsey
+      expect(dep[:deepness]).to eq(0)
+
+      dep = proj.dependencies[1]
+      expect(dep[:name]).to eq(product2[:name])
+      expect(dep[:version_requested]).to eq(product2[:version])
+      expect(dep[:version_current]).to eq(product2[:version])
+      expect(dep[:outdated]).to be_falsey
+      expect(dep[:transitive]).to be_truthy
+      expect(dep[:deepness]).to eq(1)
+
+      dep = proj.dependencies[2]
+      expect(dep[:name]).to eq(product3[:name])
+      expect(dep[:version_requested]).to eq(product3[:version])
+      expect(dep[:version_current]).to eq(product3[:version])
+      expect(dep[:outdated]).to be_falsey
+      expect(dep[:transitive]).to be_truthy
+      expect(dep[:deepness]).to eq(1)
+
+      dep = proj.dependencies[3]
+      expect(dep[:name]).to eq(product4[:name])
+      expect(dep[:version_requested]).to eq(product4[:version])
+      expect(dep[:version_current]).to eq(product4[:version])
+      expect(dep[:outdated]).to be_falsey
+      expect(dep[:transitive]).to be_truthy
+      expect(dep[:deepness]).to eq(2)
+
+      dep = proj.dependencies[4]
+      expect(dep[:name]).to eq(product5[:name])
+      expect(dep[:version_requested]).to eq(product5[:version])
+      expect(dep[:version_current]).to eq(product5[:version])
+      expect(dep[:outdated]).to be_falsey
+      expect(dep[:transitive]).to be_truthy
+      expect(dep[:deepness]).to eq(2)
+
+      dep = proj.dependencies[5]
+      expect(dep[:name]).to eq(product6[:name])
+      expect(dep[:version_requested]).to eq(product6[:version])
+      expect(dep[:version_current]).to eq(product6[:version])
+      expect(dep[:outdated]).to be_falsey
+      expect(dep[:transitive]).to be_truthy
+      expect(dep[:deepness]).to eq(2)
+
+      dep = proj.dependencies[6]
+      expect(dep[:name]).to eq(product7[:name])
+      expect(dep[:version_requested]).to eq(product7[:version])
+      expect(dep[:version_current]).to eq(product7[:version])
+      expect(dep[:outdated]).to be_falsey
+      expect(dep[:transitive]).to be_truthy
+      expect(dep[:deepness]).to eq(3)
+
+      dep = proj.dependencies[7]
+      expect(dep[:name]).to eq(product8[:name])
+      expect(dep[:version_requested]).to eq('0.0.10')
+      expect(dep[:version_current]).to eq(product8[:version])
+      expect(dep[:outdated]).to be_truthy
+      expect(dep[:transitive]).to be_truthy
+      expect(dep[:deepness]).to eq(3)
+
+    end
+  end
+end


### PR DESCRIPTION
Hi,

i added custom parser for [npm-shrinkwrap.json](https://docs.npmjs.com/cli/shrinkwrap) by extending existing `PackageParser`.

It collects root-dependencies and all the recursive sub-dependencies. 

It's not very fast for huge project files. For example [this project file](https://github.com/CRogers/gates/blob/master/npm-shrinkwrap.json) takes ~50seconds to parse;