### PR TITLE
Add additional testcases for the `CargoParser`

### DIFF
--- a/lib/versioneye/parsers/cargo_parser.rb
+++ b/lib/versioneye/parsers/cargo_parser.rb
@@ -150,6 +150,7 @@ class CargoParser < CommonParser
     if product.nil?
       log.error "dependency #{dependency} has no product or its unknown"
       dependency[:version_requested] = version
+      dependency[:version_label]     = version
       return dependency
     end
 

--- a/spec/versioneye/parsers/cargo_parser_spec.rb
+++ b/spec/versioneye/parsers/cargo_parser_spec.rb
@@ -96,6 +96,15 @@ describe CargoParser do
       expect(dep[:comperator]).to eq('=')
     end
 
+    it "uses version label when product is nil" do
+      dep = parser.parse_requested_version('^0.2', dep1, nil)
+
+      expect(dep).not_to be_nil
+      expect(dep[:version_requested]).to eq('^0.2')
+      expect(dep[:version_label]).to eq('^0.2')
+      expect(dep[:comperator]).to eq('=')
+    end
+
     it "uses latest product version if version label is *, x, X" do
       dep = parser.parse_requested_version("*", dep1, product1)
 


### PR DESCRIPTION
It adds additional test cases to check correctness of:

* it uses original versionlabel if no product
* it parses correctly `^0.3` and skips version `0.4.0`
* it parses correctly `^0.3` and makes sure that latest release `0.3.15` is not marked as outdated