### PR TITLE
Add initial version of jspm parser

### DIFF
--- a/lib/versioneye-core.rb
+++ b/lib/versioneye-core.rb
@@ -62,7 +62,7 @@ class VersioneyeCore
     MavenRepository.fill_it
 
     puts "START to import spdx licenses"
-    LicenseService.import_from "/app/data/spdx_license.csv"
+    #LicenseService.import_from "/app/data/spdx_license.csv"
     puts "---"
   rescue => e
     log.error e.message

--- a/lib/versioneye/models/project.rb
+++ b/lib/versioneye/models/project.rb
@@ -21,6 +21,7 @@ class Project < Versioneye::Model
   A_TYPE_GODEP     = 'Godep'
   A_TYPE_CPAN      = 'Cpan'
   A_TYPE_CARGO     = 'Cargo'
+  A_TYPE_JSPM      = 'Jspm'
 
   A_SOURCE_UPLOAD    = 'upload'
   A_SOURCE_URL       = 'url'

--- a/lib/versioneye/parsers/jspm_parser.rb
+++ b/lib/versioneye/parsers/jspm_parser.rb
@@ -1,0 +1,102 @@
+require 'versioneye/parsers/package_parser'
+require 'semverly'
+
+class JspmParser < PackageParser
+
+
+  def parse_content(content, token = nil)
+    return nil if content.to_s.empty?
+    return nil if content.to_s.strip.eql?('Not Found')
+
+    proj_doc = JSON.parse(content, symbolize_names: true)
+    if proj_doc.to_s.empty?
+      log.error "Project document is empty - stopping parser"
+      return nil
+    end
+
+    parse_project_doc proj_doc
+  rescue => e
+    log.error e.message
+    log.error e.backtrace.join("\n")
+    nil
+  end
+
+  # use parent_id to connect it with parent Nodejs package file
+  def parse_project_doc(proj_doc, parent_id = nil)
+    if proj_doc.nil? or proj_doc.has_key?(:jspm) == false
+      log.error "JSPM project file has no `:jspm` subdocument: {proj_doc}"
+      return nil
+    end
+
+    # JSPM is usually embedded into parent package.json file
+    project = init_project(proj_doc, parent_id)
+    jspm_doc = proj_doc[:jspm]
+
+    parse_dependencies(
+      project, jspm_doc[:dependencies], Dependency::A_SCOPE_COMPILE, proj_doc[:registry]
+    )
+    parse_dependencies(
+      project, jspm_doc[:devDependencies], Dependency::A_SCOPE_DEVELOPMENT, proj_doc[:registry]
+    )
+
+    parse_dependencies(
+      project, jspm_doc[:peerDependencies], Dependency::A_SCOPE_OPTIONAL, proj_doc[:registry]
+    )
+
+    project.dep_number = project.dependencies.size
+    project
+  rescue => e
+    log.error e.message
+    log.error e.backtrace.join("\n")
+    nil
+  end
+
+  def parse_dependencies(project, deps, scope, default_registry = nil)
+    deps.to_a.each do |pkg_id, dep_line|
+      parse_dependency(project, pkg_id.to_s, dep_line, scope, default_registry)
+    end
+
+    project
+  end
+
+
+  def parse_dependency(project, pkg_id, dep_line, scope, default_registry)
+    if dep_line[0..5] == 'github'
+      #TODO if pkg is from GITHUB
+      version_label = 'git'
+      product = nil
+    else
+      version_label = dep_line.to_s.split('@').last
+      product = Product::fetch_product(Product::A_LANGUAGE_NODEJS, pkg_id)
+    end
+
+
+    dep = init_dependency(product, pkg_id)
+    dep[:scope] = scope
+    parse_requested_version( version_label, dep, product )
+
+    project.projectdependencies.push dep
+    project.out_number     += 1 if ProjectdependencyService.outdated?( dep )
+    project.unknown_number += 1 if product.nil?
+    project
+  end
+
+  def init_project(proj_doc, parent_id = nil)
+    project_name = if proj_doc.has_key?(:name)
+                      proj_doc[:name]
+                   elsif proj_doc[:jspm].has_key?(:name)
+                      proj_doc[:jspm][:name]
+                   else
+                      "jspm_project" + Time.now.to_i
+                   end
+
+    Project.new(
+      parent_id: parent_id,
+      name: project_name,
+      project_type: Project::A_TYPE_JSPM,
+      language: Product::A_LANGUAGE_NODEJS,
+      description: proj_doc[:description],
+      version: proj_doc[:version]
+    )
+  end
+end

--- a/lib/versioneye/parsers/package_parser.rb
+++ b/lib/versioneye/parsers/package_parser.rb
@@ -49,13 +49,15 @@ class PackageParser < CommonParser
     end
     project.dep_number = project.dependencies.size
 
-    if data.has_key?['jspm']
+    if data.has_key?('jspm')
+      log.info "going to parse child JSPM project dependencies"
       jspm_parser = JspmParser.new
       #JSPM parser expects that all the fields are keywords
       symbolized_doc = JSON.parse(content, symbolize_names: true)
-      child_project = jspm_parser.parse_project_doc(symbolized_doc, project.id)
+      child_project = jspm_parser.parse_project_doc(symbolized_doc, project.id.to_s)
       if child_project
-        project_dep_number += child_project.dependencies.size
+        project.dep_number += child_project.dependencies.size
+        child_project.save
       end
     end
 

--- a/lib/versioneye/parsers/package_parser.rb
+++ b/lib/versioneye/parsers/package_parser.rb
@@ -327,15 +327,4 @@ class PackageParser < CommonParser
     end
     version
   end
-
-  #TODO: remove it as it is used nowhere
-  def parse_json_safely(json_txt, keywordize =  true)
-    json_txt = json_txt.to_s.strip
-    return nil if json_txt.nil?
-
-    JSON.parse(json_txt, symbolize_names: (keywordize == true) )
-  rescue
-    logger.error "parse_json_safely: failed to parse json text: `#{json_txt}`"
-    nil
-  end
 end

--- a/lib/versioneye/parsers/shrinkwrap_parser.rb
+++ b/lib/versioneye/parsers/shrinkwrap_parser.rb
@@ -73,4 +73,15 @@ class ShrinkwrapParser < PackageParser
 
     dep
   end
+
+  def parse_json_safely(json_txt, keywordize =  true)
+    json_txt = json_txt.to_s.strip
+    return nil if json_txt.nil?
+
+    JSON.parse(json_txt, symbolize_names: keywordize )
+  rescue
+    logger.error "parse_json_safely: failed to parse json text: `#{json_txt}`"
+    nil
+  end
+
 end

--- a/lib/versioneye/service.rb
+++ b/lib/versioneye/service.rb
@@ -103,6 +103,7 @@ module Versioneye
     require 'versioneye/parsers/shrinkwrap_parser'
     require 'versioneye/parsers/cargo_parser'
     require 'versioneye/parsers/cargo_lock_parser'
+    require 'versioneye/parsers/jspm_parser'
 
     require 'versioneye/updaters/update_strategy'
     require 'versioneye/updaters/common_updater'

--- a/lib/versioneye/services/version_service.rb
+++ b/lib/versioneye/services/version_service.rb
@@ -205,7 +205,7 @@ class VersionService < Versioneye::Service
 
   #nuget allows to specify version by combining greater_than and smaller_than
   def self.intersect_versions(versions1, versions2, range = true)
-    all_versions = versions1.concat versions2
+    all_versions = versions1.to_a.concat versions2.to_a
     common_version_labels = Set.new(versions1.to_a.map(&:version)) & Set.new(versions2.to_a.map(&:version))
     common_versions = all_versions.keep_if do |ver|
       result = false

--- a/spec/fixtures/files/npm/package_jspm.json
+++ b/spec/fixtures/files/npm/package_jspm.json
@@ -1,0 +1,60 @@
+{
+  "jspm": {
+    "name": "jspm-react-component",
+    "dependencies": {
+      "react-dom": "npm:react-dom@^0.14.6"
+    },
+    "devDependencies": {
+      "plugin-babel": "npm:systemjs-plugin-babel@^0.0.5",
+      "systemjs-hot-reloader": "github:capaj/systemjs-hot-reloader@^0.5.1"
+    },
+    "peerDependencies": {
+      "core-js": "npm:core-js@^1.2.0"
+    },
+    "overrides": {
+      "github:capaj/systemjs-hot-reloader@0.5.5": {
+        "format": "detect",
+        "meta": {}
+      },
+      "npm:babel-runtime@5.8.34": {
+        "main": false,
+        "dependencies": {},
+        "optionalDependencies": {
+          "core-js": "^1.2.0"
+        }
+      },
+      "npm:fbjs@0.6.1": {
+        "dependencies": {}
+      },
+      "npm:inherits@2.0.1": {
+        "ignore": [
+          "test.js"
+        ]
+      },
+      "npm:react@0.14.6": {
+        "dependencies": {
+          "fbjs": "^0.6.1"
+        },
+        "format": "cjs",
+        "meta": {
+          "*": {
+            "globals": {
+              "process": "process"
+            }
+          }
+        },
+        "map": {
+          "fbjs/lib/ExecutionEnvironment.js": {
+            "production": "@empty"
+          },
+          "./lib/ReactDefaultPerf.js": {
+            "production": "@empty"
+          },
+          "./lib/ReactTestUtils.js": {
+            "production": "@empty"
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/fixtures/files/npm/package_jspm_child.json
+++ b/spec/fixtures/files/npm/package_jspm_child.json
@@ -1,0 +1,28 @@
+{
+  "name": "backbone-parse-es6",
+  "version": "0.1.0",
+  "homepage": "https://github.com/typhonjs-backbone-parse/backbone-parse-es6/",
+  "description": "An extension to Backbone-ES6 adding support for the Parse 1.6+ SDK.",
+  "license": "MPL-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/typhonjs-backbone-parse/backbone-parse-es6.git"
+  },
+  "bugs": {
+    "url": "https://github.com/typhonjs-backbone-parse/backbone-parse-es6/issues"
+  },
+  "jspm": {
+    "main": "src/ModuleRuntime.js",
+    "dependencies": {
+      "backbone-es6": "github:typhonjs-backbone/backbone-es6@master",
+      "underscore": "npm:underscore@^1.0.0"
+    },
+    "devDependencies": {
+      "babel": "npm:babel-core@^5.0.0"
+    }
+  },
+  "devDependencies": {
+    "gulp": "^3.0.0",
+    "jspm": "^0.16.0"
+  }
+}

--- a/spec/versioneye/parsers/jspm_parser_spec.rb
+++ b/spec/versioneye/parsers/jspm_parser_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+describe JspmParser do
+  let(:parser){ JspmParser.new }
+  let(:test_content){ File.read('spec/fixtures/files/npm/package_jspm.json') }
+
+  let(:react_dom){
+    Product.new(
+      language: Product::A_LANGUAGE_NODEJS,
+      prod_type: Project::A_TYPE_NPM,
+      prod_key: 'react-dom',
+      name: 'react-dom',
+      version: '0.14.9'
+    )
+  }
+
+  let(:plugin_babel){
+    Product.new(
+      language: Product::A_LANGUAGE_NODEJS,
+      prod_type: Project::A_TYPE_NPM,
+      prod_key: 'plugin-babel',
+      name: 'plugin-babel',
+      version: '0.1.0'
+    )
+  }
+
+  let(:core_js){
+    Product.new(
+      language: Product::A_LANGUAGE_NODEJS,
+      prod_type: Project::A_TYPE_NPM,
+      prod_key: 'core-js',
+      name: 'core-js',
+      version: '1.3.0'
+    )
+  }
+
+  context "parse_content" do
+    before do
+      react_dom.versions << Version.new(version: '0.14.6')
+      react_dom.versions << Version.new(version: '0.14.9')
+      react_dom.save
+
+      plugin_babel.versions << Version.new(version: '0.0.5')
+      plugin_babel.versions << Version.new(version: '0.0.8')
+      plugin_babel.versions << Version.new(version: '0.1.0')
+      plugin_babel.save
+
+      core_js.versions << Version.new(version: '1.2.0')
+      core_js.versions << Version.new(version: '1.2.5')
+      core_js.versions << Version.new(version: '1.3.0')
+      core_js.save
+    end
+
+    it "parses correctly test file" do
+      proj = parser.parse_content test_content
+      expect(proj).not_to be_nil
+      expect(proj.dependencies.size).to eq(4)
+
+      dep1 = proj.dependencies[0]
+      expect(dep1[:name]).to eq(react_dom[:name])
+      expect(dep1[:prod_key]).to eq(react_dom[:prod_key])
+      expect(dep1[:language]).to eq(react_dom[:language])
+      expect(dep1[:scope]).to eq(Dependency::A_SCOPE_COMPILE)
+      expect(dep1[:version_requested]).to eq('0.14.9')
+      expect(dep1[:version_label]).to eq('^0.14.6')
+      expect(dep1[:comperator]).to eq('^')
+      expect(dep1[:outdated]).to be_falsey
+
+      dep2 = proj.dependencies[1]
+      expect(dep2[:name]).to eq(plugin_babel[:name])
+      expect(dep2[:prod_key]).to eq(plugin_babel[:prod_key])
+      expect(dep2[:language]).to eq(plugin_babel[:language])
+      expect(dep2[:scope]).to eq(Dependency::A_SCOPE_DEVELOPMENT)
+      expect(dep2[:version_requested]).to eq('0.0.8')
+      expect(dep2[:version_label]).to eq('^0.0.5')
+      expect(dep2[:comperator]).to eq('^')
+      expect(dep2[:outdated]).to be_truthy
+
+      dep3 = proj.dependencies[2]
+      expect(dep3[:name]).to eq('systemjs-hot-reloader')
+      expect(dep3[:prod_key]).to be_nil
+      expect(dep3[:language]).to eq(plugin_babel[:language])
+      expect(dep3[:scope]).to eq(Dependency::A_SCOPE_DEVELOPMENT)
+      expect(dep3[:version_requested]).to eq('git')
+      expect(dep3[:version_label]).to eq('git')
+      expect(dep3[:comperator]).to eq('=')
+      expect(dep3[:outdated]).to be_falsey
+
+      dep4 = proj.dependencies[3]
+      expect(dep4[:name]).to eq(core_js[:name])
+      expect(dep4[:prod_key]).to eq(core_js[:prod_key])
+      expect(dep4[:language]).to eq(core_js[:language])
+      expect(dep4[:scope]).to eq(Dependency::A_SCOPE_OPTIONAL)
+      expect(dep4[:version_requested]).to eq('1.3.0')
+      expect(dep4[:version_label]).to eq('^1.2.0')
+      expect(dep4[:comperator]).to eq('^')
+      expect(dep4[:outdated]).to be_falsey
+
+    end
+  end
+
+end

--- a/spec/versioneye/parsers/package_with_jspm_child_spec.rb
+++ b/spec/versioneye/parsers/package_with_jspm_child_spec.rb
@@ -1,0 +1,146 @@
+require 'spec_helper'
+
+describe PackageParser do
+  let(:parser){ PackageParser.new }
+  let(:test_content){ File.read('spec/fixtures/files/npm/package_jspm_child.json') }
+
+  let(:backbone_es6){
+    Product.new(
+      language: Product::A_LANGUAGE_NODEJS,
+      prod_type: Project::A_TYPE_NPM,
+      prod_key: 'backbone-es6',
+      name: 'backbone-es6',
+      version: '1.0.0'
+    )
+  }
+
+  let(:underscore){
+    Product.new(
+      language: Product::A_LANGUAGE_NODEJS,
+      prod_type: Project::A_TYPE_NPM,
+      prod_key: 'underscore',
+      name: 'underscore',
+      version: '1.0.0'
+    )
+  }
+
+  let(:babel){
+    Product.new(
+      language: Product::A_LANGUAGE_NODEJS,
+      prod_type: Project::A_TYPE_NPM,
+      prod_key: 'babel',
+      name: 'babel',
+      version: '5.0.0'
+    )
+  }
+
+  let(:gulp){
+    Product.new(
+      language: Product::A_LANGUAGE_NODEJS,
+      prod_type: Project::A_TYPE_NPM,
+      prod_key: 'gulp',
+      name: 'gulp',
+      version: '3.0.0'
+    )
+  }
+
+  let(:jspm){
+    Product.new(
+      language: Product::A_LANGUAGE_NODEJS,
+      prod_type: Project::A_TYPE_NPM,
+      prod_key: 'jspm',
+      name: 'jspm',
+      version: '0.16.0'
+    )
+  }
+
+  # it should parse correclty dependencies of NPM packages
+  # and then create child_project for JSPM dependencies
+  context "parse_content" do
+    before do
+      backbone_es6.save;
+
+      underscore.versions << Version.new(version: '1.0.0')
+      underscore.save
+
+      babel.save
+
+      gulp.versions << Version.new(version: '3.0.0')
+      gulp.save
+
+      jspm.versions << Version.new(version: '0.16.0')
+      jspm.save
+    end
+
+    after do
+      Project.delete_all
+      Projectdependency.delete_all
+    end
+
+    it "parses test file correctly" do
+      proj = parser.parse_content test_content
+      expect(proj).not_to be_nil
+      expect(proj.dependencies.size).to eq(2)
+      expect(proj.dep_number).to eq(5) #2 NPM + 3 JSPM deps
+
+      # check did we get all the dependencies for parent project right
+      dep1 = proj.dependencies[0]
+      expect(dep1[:name]).to eq(gulp[:name])
+      expect(dep1[:prod_key]).to eq(gulp[:prod_key])
+      expect(dep1[:language]).to eq(gulp[:language])
+      expect(dep1[:scope]).to eq(Dependency::A_SCOPE_DEVELOPMENT)
+      expect(dep1[:version_requested]).to eq('3.0.0')
+      expect(dep1[:version_label]).to eq('^3.0.0')
+      expect(dep1[:comperator]).to eq('^')
+      expect(dep1[:outdated]).to be_falsey
+
+      dep2 = proj.dependencies[1]
+      expect(dep2[:name]).to eq(jspm[:name])
+      expect(dep2[:prod_key]).to eq(jspm[:prod_key])
+      expect(dep2[:language]).to eq(jspm[:language])
+      expect(dep2[:scope]).to eq(Dependency::A_SCOPE_DEVELOPMENT)
+      expect(dep2[:version_requested]).to eq('0.16.0')
+      expect(dep2[:version_label]).to eq('^0.16.0')
+      expect(dep2[:comperator]).to eq('^')
+      expect(dep2[:outdated]).to be_falsey
+
+      # check did we get all the dependencies for JSPM project right
+      jspm_proj = proj.children.first
+      expect(jspm_proj).not_to be_nil
+      expect(jspm_proj.dependencies.size).to eq(3)
+      expect(jspm_proj.dep_number).to eq(3) #only its own deps 3 JSPM deps
+
+
+      cdep1 = jspm_proj.dependencies[0]
+      expect(cdep1[:name]).to eq(backbone_es6[:name])
+      expect(cdep1[:prod_key]).to eq(backbone_es6[:prod_key])
+      expect(cdep1[:language]).to eq(backbone_es6[:language])
+      expect(cdep1[:scope]).to eq(Dependency::A_SCOPE_COMPILE)
+      expect(cdep1[:version_requested]).to eq('git')
+      expect(cdep1[:version_label]).to eq('git')
+      expect(cdep1[:comperator]).to eq('=')
+      expect(cdep1[:outdated]).to be_falsey
+
+      cdep2 = jspm_proj.dependencies[1]
+      expect(cdep2[:name]).to eq(underscore[:name])
+      expect(cdep2[:prod_key]).to eq(underscore[:prod_key])
+      expect(cdep2[:language]).to eq(underscore[:language])
+      expect(cdep2[:scope]).to eq(Dependency::A_SCOPE_COMPILE)
+      expect(cdep2[:version_requested]).to eq('1.0.0')
+      expect(cdep2[:version_label]).to eq('^1.0.0')
+      expect(cdep2[:comperator]).to eq('^')
+      expect(cdep2[:outdated]).to be_falsey
+
+      cdep3 = jspm_proj.dependencies[2]
+      expect(cdep3[:name]).to eq(babel[:name])
+      expect(cdep3[:prod_key]).to eq(babel[:prod_key])
+      expect(cdep3[:language]).to eq(babel[:language])
+      expect(cdep3[:scope]).to eq(Dependency::A_SCOPE_DEVELOPMENT)
+      expect(cdep3[:version_requested]).to eq('5.0.0')
+      expect(cdep3[:version_label]).to eq('^5.0.0')
+      expect(cdep3[:comperator]).to eq('^')
+      expect(cdep3[:outdated]).to be_falsey
+
+    end
+  end
+end


### PR DESCRIPTION
Hi,

i added initial support for [JSPM](http://jspm.io). Current version supports only `npm` dependencies, as there's no crawlers got git-deps or `jspm` registry;

As JSPM is sub-document of `Package.json` file, then i extended existing `PackageParser`, which will save `JSPM` dependencies into child-project.

I also find one failing tests for Rust's `CargoParser`.


* [issue on bitbucket ](https://bitbucket.org/versioneye/versioneye/issues/134/support-jspm-package-manager#comment-36757858)