### PR TITLE
Add csproj parser

### DIFF
--- a/lib/versioneye/parsers/common_parser.rb
+++ b/lib/versioneye/parsers/common_parser.rb
@@ -114,6 +114,7 @@ class CommonParser
     dependency
   end
 
+  #TODO: it's should really be called as parse_xml and should handle parse error
   def fetch_xml( content )
     doc = Nokogiri::XML( content )
     return nil if doc.nil?

--- a/lib/versioneye/parsers/csproj_parser.rb
+++ b/lib/versioneye/parsers/csproj_parser.rb
@@ -1,0 +1,28 @@
+require 'versioneye/parsers/nuget_parser'
+
+class CsprojParser < NugetParser
+
+  #read all dependency data from project file
+  def parse_dependencies(doc)
+    deps = []
+    doc.xpath('//Project/ItemGroup/PackageReference').each do |pkg_node|
+      dep = parse_dependency(pkg_node)
+      deps << dep if dep.nil? == false
+    end
+
+    deps
+  end
+
+  def parse_dependency(pkg_node)
+    prod_key = pkg_node.attr('Include').to_s.strip
+    version_label = if pkg_node.has_attribute?('Version')
+                      pkg_node.attr('Version').to_s.strip
+                    else
+                      #version wasnt specified as attribute, check child nodes
+                      pkg_node.xpath('//Version').text
+                    end
+
+    init_dependency(prod_key, version_label, nil, Dependency::A_SCOPE_COMPILE)
+  end
+
+end

--- a/lib/versioneye/parsers/nuget_parser.rb
+++ b/lib/versioneye/parsers/nuget_parser.rb
@@ -113,7 +113,7 @@ class NugetParser < CommonParser
     parse_content( response_body, url )
   end
 
-  def parse_content( response_body, url )
+  def parse_content( response_body, url = nil)
     deps = []
 
     doc     = fetch_xml( response_body )
@@ -340,4 +340,18 @@ class NugetParser < CommonParser
 
     project
   end
+
+  def init_dependency(prod_key, version_label, target = nil, scope = nil)
+    return if prod_key.nil?
+
+    Projectdependency.new(
+      language: Product::A_LANGUAGE_CSHARP,
+      prod_key: prod_key,
+      name: prod_key,
+      version_label: version_label,
+      target: target,
+      scope: scope
+    )
+  end
+
 end

--- a/lib/versioneye/parsers/parser_strategy.rb
+++ b/lib/versioneye/parsers/parser_strategy.rb
@@ -82,6 +82,8 @@ class ParserStrategy
           return NugetJsonParser.new
         when /packages\.config/i
           return NugetPackagesParser.new
+        when /\.csproj/i
+          return CsprojParser.new
         else
           return NugetParser.new
         end

--- a/lib/versioneye/service.rb
+++ b/lib/versioneye/service.rb
@@ -104,6 +104,7 @@ module Versioneye
     require 'versioneye/parsers/cargo_parser'
     require 'versioneye/parsers/cargo_lock_parser'
     require 'versioneye/parsers/jspm_parser'
+    require 'versioneye/parsers/csproj_parser'
 
     require 'versioneye/updaters/update_strategy'
     require 'versioneye/updaters/common_updater'

--- a/lib/versioneye/services/project_import_service.rb
+++ b/lib/versioneye/services/project_import_service.rb
@@ -8,7 +8,7 @@ class ProjectImportService < Versioneye::Service
   def self.import_all_github user, orga_id, pfs = [
     'Gemfile', 'Gemfile.lock', '.gemspec', 'package.json', 'pom.xml', 'bower.json',
     'Podfile', 'Podfile.lock', '.gradle', 'yarn.lock', 'npm-shrinkwrap.json',
-    'Cargo.toml', 'Cargo.lock'
+    'Cargo.toml', 'Cargo.lock', '.csproj'
     ], max_depth = 2
     user.github_repos.where(:fullname => /\Ablinkist/, :private => true).each do |repo|
       if repo.branches.to_a.empty?

--- a/lib/versioneye/services/project_service.rb
+++ b/lib/versioneye/services/project_service.rb
@@ -33,7 +33,15 @@ class ProjectService < Versioneye::Service
     return Project::A_TYPE_BIICODE   if (!(/biicode.conf\z/ =~ trimmed_name).nil?)
     return Project::A_TYPE_COCOAPODS if (!(/Podfile\z/ =~ trimmed_name).nil?)  or (!(/.podfile\z/ =~ trimmed_name).nil?) or (!(/Podfile.lock\z/ =~ trimmed_name).nil?)
     return Project::A_TYPE_CHEF      if (!(/Berksfile.lock\z/ =~ trimmed_name).nil?)  or (!(/Berksfile\z/ =~ trimmed_name).nil?) or (!(/metadata.rb\z/ =~ trimmed_name).nil?)
-    return Project::A_TYPE_NUGET     if (!(/project\.json\z/ =~ trimmed_name).nil?) or (!(/.*\.nuspec\z/ =~ trimmed_name).nil?)  or (!(/packages\.config\z/ =~ trimmed_name).nil?)
+
+    if (!(/project\.json\z/ =~ trimmed_name).nil?) \
+        or (!(/.*\.nuspec\z/ =~ trimmed_name).nil?)  \
+        or (!(/packages\.config\z/ =~ trimmed_name).nil?) \
+        or (!(/.*\.csproj\z/ =~ trimmed_name).nil? )
+
+      return Project::A_TYPE_NUGET
+    end
+
     return Project::A_TYPE_CPAN      if (/\Acpanfile\z/i =~ trimmed_name) != nil
     return Project::A_TYPE_CARGO     if (/Cargo\.toml\z/i =~ trimmed_name) != nil or (/Cargo\.lock\z/i =~ trimmed_name ) != nil
 

--- a/spec/fixtures/files/nuget/test.csproj
+++ b/spec/fixtures/files/nuget/test.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="[1.3.2,1.5)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
+    <PackageReference Include="Microsoft.NETCore.App">
+      <Version>1.1.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Bank.Dto\Bank.Dto.csproj" />
+    <ProjectReference Include="..\Bank.Entities\Bank.Entities.csproj" />
+    <ProjectReference Include="..\Bank.Infrastructures\Bank.Infrastructures.csproj" />
+    <ProjectReference Include="..\Bank.Models\Bank.Models.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/spec/versioneye/parsers/csproj_parser_spec.rb
+++ b/spec/versioneye/parsers/csproj_parser_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+describe 'CsprojParser' do
+  let(:parser){ CsprojParser.new }
+  let(:test_content){ File.read('spec/fixtures/files/nuget/test.csproj') }
+
+  let(:product1){
+    Product.new(
+      language: Product::A_LANGUAGE_CSHARP,
+      prod_type: Project::A_TYPE_NUGET,
+      prod_key: 'Microsoft.EntityFrameworkCore',
+      name: 'Microsoft.EntityFrameworkCore',
+      version: '1.6.5'
+    )
+  }
+
+  let(:product2){
+    Product.new(
+      language: Product::A_LANGUAGE_CSHARP,
+      prod_type: Project::A_TYPE_NUGET,
+      prod_key: 'Microsoft.NETCore.App',
+      name: 'Microsoft.NETCore.App',
+      version: '2.0.0'
+    )
+  }
+
+  context "parse_dependencies" do
+
+    it "extracts correct list of dependencies from the test file" do
+      xml_doc = parser.fetch_xml test_content
+      expect(xml_doc).not_to be_nil
+
+      deps = parser.parse_dependencies(xml_doc)
+      expect(deps.size).to eq(2)
+
+      expect(deps[0][:language]).to eq(product1[:language])
+      expect(deps[0][:prod_key]).to eq(product1[:prod_key])
+      expect(deps[0][:name]).to eq(product1[:name])
+      expect(deps[0][:version_label]).to eq('[1.3.2,1.5)')
+
+      expect(deps[1][:language]).to eq(product2[:language])
+      expect(deps[1][:prod_key]).to eq(product2[:prod_key])
+      expect(deps[1][:name]).to eq(product2[:name])
+      expect(deps[1][:version_label]).to eq('1.1.0')
+
+    end
+  end
+
+  context "parse_content" do
+    before do
+      product1.versions << Version.new(version: '1.3.0')
+      product1.versions << Version.new(version: '1.4.0')
+      product1.versions << Version.new(version: '1.6.5')
+      product1.save
+
+      product2.versions << Version.new(version: '1.1.0')
+      product2.save
+    end
+
+    it "parses test file correctly" do
+      proj = parser.parse_content test_content
+      expect(proj).not_to be_nil
+      expect(proj.dependencies.size).to eq(2)
+
+      dep1 = proj.dependencies[0]
+      expect(dep1[:name]).to eq(product1[:name])
+      expect(dep1[:prod_key]).to eq(product1[:prod_key])
+      expect(dep1[:language]).to eq(product1[:language])
+      expect(dep1[:scope]).to eq(Dependency::A_SCOPE_COMPILE)
+      expect(dep1[:version_requested]).to eq('1.4.0')
+      expect(dep1[:version_label]).to eq('[1.3.2,1.5)')
+      expect(dep1[:comperator]).to eq('>=x<')
+      expect(dep1[:outdated]).to be_truthy
+
+      dep2 = proj.dependencies[1]
+      expect(dep2[:name]).to eq(product2[:name])
+      expect(dep2[:prod_key]).to eq(product2[:prod_key])
+      expect(dep2[:language]).to eq(product2[:language])
+      expect(dep2[:scope]).to eq(Dependency::A_SCOPE_COMPILE)
+      expect(dep2[:version_requested]).to eq('1.1.0')
+      expect(dep2[:version_label]).to eq('1.1.0')
+      expect(dep2[:comperator]).to eq('>=')
+      expect(dep2[:outdated]).to be_falsey
+
+    end
+  end
+end

--- a/spec/versioneye/parsers/parser_strategy_spec.rb
+++ b/spec/versioneye/parsers/parser_strategy_spec.rb
@@ -90,6 +90,11 @@ describe ParserStrategy do
       expect( parser.is_a?(NugetPackagesParser) ).to be_truthy
     end
 
+    it "return CsprojParser" do
+      parser = ParserStrategy.parser_for(Project::A_TYPE_NUGET, 'veye.csproj')
+      expect( parser.is_a?(CsprojParser) ).to be_truthy
+    end
+
     it "returns NugetParser" do
       parser = ParserStrategy.parser_for(Project::A_TYPE_NUGET, "http://s3.aws.com/project.nuspec")
       expect( parser.is_a?(NugetParser) ).to be_truthy

--- a/spec/versioneye/services/project_service_spec.rb
+++ b/spec/versioneye/services/project_service_spec.rb
@@ -295,6 +295,8 @@ describe ProjectService do
     it "returns Nuget" do
       described_class.type_by_filename("/project.json").should eql(Project::A_TYPE_NUGET)
       described_class.type_by_filename("/something.nuspec").should eql(Project::A_TYPE_NUGET)
+      described_class.type_by_filename('veye.csproj').should eq(Project::A_TYPE_NUGET)
+      described_class.type_by_filename('/a/b/c/veye.csproj').should eq(Project::A_TYPE_NUGET)
     end
 
     it "returns nil for wrong Lein file" do


### PR DESCRIPTION
Hi, 

i added support for `*.csproj` files by extending existing `NugetParser`.

This PR solves the issue#379 on bitbucket: [https://bitbucket.org/versioneye/versioneye/issues/379/support-for-nuget-packages-from-csproj](https://bitbucket.org/versioneye/versioneye/issues/379/support-for-nuget-packages-from-csproj)