### PR TITLE
add method to fetch all github hooks registered on repo;

### DIFF
--- a/lib/versioneye/services_ext/github_webhook.rb
+++ b/lib/versioneye/services_ext/github_webhook.rb
@@ -95,6 +95,26 @@ class GithubWebhook < Versioneye::Service
     false
   end
 
+
+  # fetches list of registered hooks on the Github repo
+  # params:
+  #   repo_fullname: String, fullname of github repo, 'versioneye/veye'
+  #   token :  String, github access_token
+  def self.fetch_repo_hooks(repo_fullname, token)
+    if token.to_s.empty?
+      log.error "fetch_repo_hooks: no api token attached for #{repo_fullname} request"
+      return
+    end
+
+    client = Octokit::Client.new(access_token: token)
+    client.hooks(repo_fullname)
+  rescue => e
+    log.error "fetch_repo_hooks: failed to request data from API"
+    log.error e.message
+    log.error e.backtrace.join('\n')
+    nil
+  end
+
 #-- persistance helpers
   # updates or creates webhook for Versineye project
   def self.upsert_project_webhook(hook_dt, repo_fullname, project_id)

--- a/spec/fixtures/vcr_cassettes/github/webhooks/fetch_repo_hooks.yml
+++ b/spec/fixtures/vcr_cassettes/github/webhooks/fetch_repo_hooks.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.github.com/repos/timgluz/versioneye-core/hooks
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+      User-Agent:
+      - Octokit Ruby Gem 4.7.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Fri, 09 Jun 2017 13:30:47 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Status:
+      - 200 OK
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4942'
+      X-Ratelimit-Reset:
+      - '1497016525'
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      Etag:
+      - W/"4bc807d8d2a1dbd1abb763829e691863"
+      X-Oauth-Scopes:
+      - admin:org_hook, admin:repo_hook, repo
+      X-Accepted-Oauth-Scopes:
+      - admin:repo_hook, public_repo, read:repo_hook, repo, write:repo_hook
+      X-Github-Media-Type:
+      - github.v3; format=json
+      Access-Control-Expose-Headers:
+      - ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset,
+        X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy:
+      - default-src 'none'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Runtime-Rack:
+      - '0.068032'
+      X-Github-Request-Id:
+      - F98D:620A:6B07DC:893CDC:593AA307
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"type":"Repository","id":14269317,"name":"web","active":true,"events":["pull_request","push"],"config":{"api_key":"709cd0c2e2523fd268e4","content_type":"json","project_id":"593aa2002066ab005710e6b0","url":"https://www.versioneye.com/api/v2/github/hook/593aa2002066ab005710e6b0?api_key=709cd0c2e2523fd268e4","insecure_ssl":"0"},"updated_at":"2017-06-09T13:26:26Z","created_at":"2017-06-09T13:26:26Z","url":"https://api.github.com/repos/timgluz/versioneye-core/hooks/14269317","test_url":"https://api.github.com/repos/timgluz/versioneye-core/hooks/14269317/test","ping_url":"https://api.github.com/repos/timgluz/versioneye-core/hooks/14269317/pings","last_response":{"code":200,"status":"active","message":"OK"}}]'
+    http_version: 
+  recorded_at: Fri, 09 Jun 2017 13:30:47 GMT
+recorded_with: VCR 3.0.3

--- a/spec/versioneye/services_ext/github_webhook_spec.rb
+++ b/spec/versioneye/services_ext/github_webhook_spec.rb
@@ -40,6 +40,22 @@ describe GithubWebhook do
       end
     end
 
+    it "pulls right list of repos" do
+      VCR.use_cassette('github/webhooks/fetch_repo_hooks') do
+        res = GithubWebhook.fetch_repo_hooks(repo_fullname, github_token)
+
+        expect(res).not_to be_nil
+        expect(res.size).to eq(1)
+
+        hook = res.first
+        expect(hook).not_to be_nil
+        expect(hook[:type]).to eq('Repository')
+        expect(hook[:name]).to eq('web')
+        expect(hook[:id]).not_to be_nil
+        expect(hook[:config][:project_id]).to eq('593aa2002066ab005710e6b0')
+      end
+    end
+
   end
 
   let(:hook_dt){


### PR DESCRIPTION
It's required for the `rake` tasks, which could update save old project hooks in our DB;