### PR TITLE
Fix package lock parser, solves #92

### DIFF
--- a/lib/versioneye/parsers/common_parser.rb
+++ b/lib/versioneye/parsers/common_parser.rb
@@ -12,10 +12,10 @@ class CommonParser
     raise NotImplementedError, 'Implement me in subclass!'
   end
 
-  def from_json(json_doc)
+  def from_json(json_doc, as_symbols = true)
     json_doc = json_doc.force_encoding(Encoding::UTF_8).strip
     json_doc = clean_spaces(json_doc) #replace non-ascii spaces with ascii spaces
-    JSON.parse(json_doc, {symbolize_names: true})
+    JSON.parse(json_doc, {symbolize_names: as_symbols})
   rescue => e
     log.error "from_json: failed to parse #{json_doc}"
     log.error e.backtrace.join('\n')

--- a/lib/versioneye/parsers/package_lock_parser.rb
+++ b/lib/versioneye/parsers/package_lock_parser.rb
@@ -11,7 +11,7 @@ class PackageLockParser < ShrinkwrapParser
     return nil if content.empty?
     return nil if (content =~ /Not\s+found/i)
 
-    proj_doc = parse_json_safely content
+    proj_doc = from_json content
     return nil if proj_doc.nil?
 
     project = init_project({

--- a/lib/versioneye/parsers/package_parser.rb
+++ b/lib/versioneye/parsers/package_parser.rb
@@ -251,8 +251,8 @@ class PackageParser < CommonParser
         end
 
         version_range   = VersionService.version_range(product.versions, start, upper_range )
-        version_range.each do |version|
-          version_range.delete version if version.to_s.eql?(upper_range)
+        version_range.each do |v|
+          version_range.delete(v) if v.to_s.eql?(upper_range)
         end
         highest_version = VersionService.newest_version_from( version_range )
         if highest_version

--- a/lib/versioneye/parsers/package_parser.rb
+++ b/lib/versioneye/parsers/package_parser.rb
@@ -23,7 +23,7 @@ class PackageParser < CommonParser
     return nil if content.to_s.empty?
     return nil if (content =~ /Not\s+found/i)
 
-    data = JSON.parse( content )
+    data = from_json( content , false)
     return nil if data.nil?
 
     project = init_project( data )
@@ -119,7 +119,12 @@ class PackageParser < CommonParser
 
     version = pre_process version
 
-    if version.match(/\|\|/)
+    if version.match(/\Agit/)
+      commit_sha = version.split('#').to_a.last
+      dependency[:version_requested] = 'GIT'
+      dependency[:version_label] = commit_sha
+
+    elsif version.match(/\|\|/)
       parsed_versions = []
       versions = version.split("||")
       versions.each do |verso|

--- a/lib/versioneye/parsers/shrinkwrap_parser.rb
+++ b/lib/versioneye/parsers/shrinkwrap_parser.rb
@@ -6,7 +6,7 @@ class ShrinkwrapParser < PackageParser
     return nil if content.empty?
     return nil if (content =~ /Not\s+found/i)
 
-    proj_doc = parse_json_safely content
+    proj_doc = from_json content
     return nil if proj_doc.nil?
 
     project = init_project({
@@ -72,16 +72,6 @@ class ShrinkwrapParser < PackageParser
     end
 
     dep
-  end
-
-  def parse_json_safely(json_txt, keywordize =  true)
-    json_txt = json_txt.to_s.strip
-    return nil if json_txt.nil?
-
-    JSON.parse(json_txt, symbolize_names: keywordize )
-  rescue
-    logger.error "parse_json_safely: failed to parse json text: `#{json_txt}`"
-    nil
   end
 
 end

--- a/spec/fixtures/files/npm/package-lock.json
+++ b/spec/fixtures/files/npm/package-lock.json
@@ -16,7 +16,11 @@
         "end-of-stream": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-          "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4="
+          "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
+          "dependencies": {
+            "tarball-http": {"version": "https://example.com/example-1.3.0.tgz"},
+            "tarball-file": {"version": "file:///opt/storage/example-1.3.1.tgz"}
+          }
         }
       }
     }

--- a/spec/versioneye/parsers/package_lock_parser_spec.rb
+++ b/spec/versioneye/parsers/package_lock_parser_spec.rb
@@ -34,6 +34,27 @@ describe PackageLockParser do
     )
   }
 
+  let(:product4){
+    Product.new(
+      language: Product::A_LANGUAGE_NODEJS,
+      prod_type: Project::A_TYPE_NPM,
+      prod_key: 'tarball-http',
+      name: 'tarball-http',
+      version: '1.3.0'
+    )
+  }
+
+  let(:product5){
+    Product.new(
+      language: Product::A_LANGUAGE_NODEJS,
+      prod_type: Project::A_TYPE_NPM,
+      prod_key: 'tarball-file',
+      name: 'tarball-file',
+      version: '1.3.1'
+    )
+  }
+
+
   context "parse_content" do
     before do
       product1.save
@@ -41,6 +62,8 @@ describe PackageLockParser do
 
       product3.versions << Version.new(version: '1.1.0')
       product3.save
+      product4.save
+      product5.save
     end
 
     it "parses correctly project file" do
@@ -48,7 +71,7 @@ describe PackageLockParser do
       expect(proj).not_to be_nil
       expect(proj[:name]).to eq('pkg-lock-test')
       expect(proj[:version]).to eq('1.0.0')
-      expect(proj.dep_number).to eq(3)
+      expect(proj.dep_number).to eq(5)
 
       dep = proj.dependencies[0]
       expect(dep[:name]).to eq(product1[:name])
@@ -73,6 +96,23 @@ describe PackageLockParser do
       expect(dep[:outdated]).to be_truthy
       expect(dep[:transitive]).to be_truthy
       expect(dep[:deepness]).to eq(1)
+
+      dep = proj.dependencies[3]
+      expect(dep[:name]).to eq(product4[:name])
+      expect(dep[:version_requested]).to eq(product4[:version])
+      expect(dep[:version_current]).to eq(product4[:version])
+      expect(dep[:outdated]).to be_falsey
+      expect(dep[:transitive]).to be_truthy
+      expect(dep[:deepness]).to eq(2)
+
+      dep = proj.dependencies[4]
+      expect(dep[:name]).to eq(product5[:name])
+      expect(dep[:version_requested]).to eq(product5[:version])
+      expect(dep[:version_current]).to eq(product5[:version])
+      expect(dep[:outdated]).to be_falsey
+      expect(dep[:transitive]).to be_truthy
+      expect(dep[:deepness]).to eq(2)
+
 
     end
   end

--- a/spec/versioneye/parsers/package_parser_spec.rb
+++ b/spec/versioneye/parsers/package_parser_spec.rb
@@ -1,18 +1,56 @@
 require 'spec_helper'
 
 describe PackageParser do
+  let(:parser){ PackageParser.new }
+  let(:product1){ create_product('connect-redis', 'connect-redis', '1.3.0') }
+  let(:dep1){ parser.init_dependency(nil, 'test-js-pkg') }
+
+  #TODO: add test cases SEMVER comparition
+  context "parse_requested_version" do
+
+    it "parses correctly version labels with git urls" do
+      git_version = 'git+https://example.com/foo/bar#115311855adb0789a0466714ed48a1499ffea97e'
+      parser.parse_requested_version(git_version, dep1, product1)
+
+      expect(dep1).not_to be_nil
+      expect(dep1[:version_requested]).to eq('GIT')
+      expect(dep1[:version_label]).to eq('115311855adb0789a0466714ed48a1499ffea97e')
+      expect(dep1[:comperator]).to eq('=')
+    end
+
+    it "parses correctly version labels with urls with tarball" do
+      tarbal_version = 'https://example.com/example-1.3.0.tgz'
+      parser.parse_requested_version(tarbal_version, dep1, product1)
+
+      expect(dep1).not_to be_nil
+      expect(dep1[:version_requested]).to eq('1.3.0')
+      expect(dep1[:version_label]).to eq('1.3.0')
+      expect(dep1[:comperator]).to eq('=')
+    end
+
+    it "parses correctly version from filepath of the tarball" do
+      tarball_version = 'file:///opt/storage/example-1.3.0.tgz'
+      parser.parse_requested_version(tarball_version, dep1, product1)
+
+      expect(dep1).not_to be_nil
+      expect(dep1[:version_requested]).to eq('1.3.0')
+      expect(dep1[:version_label]).to eq('1.3.0')
+      expect(dep1[:comperator]).to eq('=')
+
+    end
+  end
+
 
   describe "parse" do
 
     it "parse from https the file correctly" do
-      parser = PackageParser.new
       project = parser.parse('https://s3.amazonaws.com/veye_test_env/package.json')
       expect( project ).to_not be_nil
     end
 
     it "parse from http the file correctly" do
-
       product1  = create_product('connect-redis', 'connect-redis', '1.3.0')
+
       product2  = create_product('redis'        , 'redis'        , '1.3.0')
       product3  = create_product('memcache'     , 'memcache'     , '1.4.0')
       product4  = create_product('mongo'        , 'mongo'        , '1.1.7')

--- a/spec/versioneye/parsers/package_parser_spec.rb
+++ b/spec/versioneye/parsers/package_parser_spec.rb
@@ -44,85 +44,85 @@ describe PackageParser do
       expect( project.dependencies.size ).to eql(21)
 
       dep_01 = project.dependencies.first
-      expect( dep_01.name ).to eql('connect-redis')
+      expect( dep_01.name ).to eql(product1[:name])
       expect( dep_01.version_requested ).to eql('1.3.0')
       expect( dep_01.version_current ).to eql('1.3.0')
       expect( dep_01.comperator ).to eql('=')
 
       dep_02 = project.dependencies[1]
-      expect( dep_02.name ).to eql('redis')
+      expect( dep_02.name ).to eql(product2[:name])
       expect( dep_02.version_requested ).to eql('1.3.0')
       expect( dep_02.version_current ).to eql('1.3.0')
       expect( dep_02.comperator ).to eql('=')
 
       dep_03 = project.dependencies[2]
-      expect( dep_03.name ).to eql('memcache')
+      expect( dep_03.name ).to eql(product3[:name])
       expect( dep_03.version_requested ).to eql('1.4.0')
       expect( dep_03.version_current ).to eql('1.4.0')
       expect( dep_03.comperator ).to eql('=')
 
       dep_04 = project.dependencies[3]
-      expect( dep_04.name ).to eql('mongo')
+      expect( dep_04.name ).to eql(product4[:name])
       expect( dep_04.version_requested ).to eql('1.1.7')
       expect( dep_04.version_current ).to eql('1.1.7')
       expect( dep_04.comperator ).to eql('=')
 
       dep_05 = project.dependencies[4]
-      expect( dep_05.name ).to eql('mongoid')
+      expect( dep_05.name ).to eql(product5[:name])
       expect( dep_05.version_requested ).to eql('1.1.7')
       expect( dep_05.version_current ).to eql('1.1.7')
       expect( dep_05.comperator ).to eql('=')
 
       dep_06 = project.dependencies[5]
-      expect( dep_06.name ).to eql('express')
+      expect( dep_06.name ).to eql(product6[:name])
       expect( dep_06.version_requested ).to eql('2.4.7')
       expect( dep_06.version_current ).to eql('2.4.7')
       expect( dep_06.comperator ).to eql('=')
 
       dep_07 = project.dependencies[6]
-      expect( dep_07.name ).to eql('fs-ext')
+      expect( dep_07.name ).to eql(product7[:name])
       expect( dep_07.version_requested ).to eql('0.2.7')
       expect( dep_07.version_current ).to eql('2.4.7')
       expect( dep_07.comperator ).to eql('=')
 
       dep_08 = project.dependencies[7]
-      expect( dep_08.name ).to eql('jade')
+      expect( dep_08.name ).to eql(product8[:name])
       expect( dep_08.version_requested ).to eql('0.2.7')
       expect( dep_08.version_current ).to eql('2.4.7')
       expect( dep_08.comperator ).to eql('~')
 
       dep_09 = project.dependencies[8]
-      expect( dep_09.name ).to eql('mailer')
+      expect( dep_09.name ).to eql(product9[:name])
       expect( dep_09.version_requested ).to eql('0.6.9')
       expect( dep_09.version_current ).to eql('0.7.0')
       expect( dep_09.comperator ).to eql('=')
 
       dep_10 = project.dependencies[9]
-      expect( dep_10.name ).to eql('markdown')
+      expect( dep_10.name ).to eql(product10[:name])
       expect( dep_10.version_requested ).to eql('0.2.0')
       expect( dep_10.version_current ).to eql('0.4.0')
       expect( dep_10.comperator ).to eql('<')
 
       dep_11 = project.dependencies[10]
-      expect( dep_11.name ).to eql('mu2')
+      expect( dep_11.name ).to eql(product11[:name])
       expect( dep_11.version_requested ).to eql('0.6.0')
       expect( dep_11.version_current ).to eql('0.6.0')
       expect( dep_11.comperator ).to eql('>')
 
       dep_12 = project.dependencies[11]
-      expect( dep_12.name ).to eql('pg')
+      expect( dep_12.name ).to eql(product12[:name])
       expect( dep_12.version_requested ).to eql('0.6.6')
       expect( dep_12.version_current ).to eql('0.6.6')
       expect( dep_12.comperator ).to eql('>=')
 
       dep_13 = project.dependencies[12]
-      expect( dep_13.name ).to eql('pg_connect')
+      expect( dep_13.name ).to eql(product13[:name])
       expect( dep_13.version_requested ).to eql('0.6.9')
       expect( dep_13.version_current ).to eql('0.6.9')
       expect( dep_13.comperator ).to eql('<=')
 
       dep_14 = project.dependencies[13]
-      expect( dep_14.name ).to eql('mocha')
+      expect( dep_14.name ).to eql(product14[:name])
       expect( dep_14.version_requested ).to eql('1.16.2')
       expect( dep_14.version_current ).to eql('1.16.2')
       expect( dep_14.comperator ).to eql('=')
@@ -130,7 +130,7 @@ describe PackageParser do
       expect( dep_14.outdated?() ).to be_falsey
 
       dep_15 = project.dependencies[14]
-      expect( dep_15.name ).to eql('bruno')
+      expect( dep_15.name ).to eql(product15[:name])
       expect( dep_15.version_requested ).to eql('1.12.1')
       expect( dep_15.version_current ).to eql('1.12.1')
       expect( dep_15.comperator ).to eql('^')
@@ -138,7 +138,7 @@ describe PackageParser do
       expect( dep_15.outdated?() ).to be_falsey
 
       dep_15 = project.dependencies[15]
-      expect( dep_15.name ).to eql('gulp')
+      expect( dep_15.name ).to eql(product16[:name])
       expect( dep_15.version_requested ).to eql('1.12.1')
       expect( dep_15.version_current ).to eql('1.12.1')
       expect( dep_15.comperator ).to eql('!=')
@@ -146,7 +146,7 @@ describe PackageParser do
       expect( dep_15.outdated?() ).to be_falsey
 
       dep_16 = project.dependencies[16]
-      expect( dep_16.name ).to eql('async')
+      expect( dep_16.name ).to eql(product17[:name])
       expect( dep_16.version_requested ).to eql('0.9.0')
       expect( dep_16.version_current ).to eql('0.9.0')
       expect( dep_16.comperator ).to eql('=')
@@ -154,7 +154,7 @@ describe PackageParser do
       expect( dep_16.outdated?() ).to be_falsey
 
       dep_17 = project.dependencies[17]
-      expect( dep_17.name ).to eql('gulp-webserver')
+      expect( dep_17.name ).to eql(product18[:name])
       expect( dep_17.version_label ).to eql('^0.9.*')
       expect( dep_17.version_requested ).to eql('0.9.1')
       expect( dep_17.version_current ).to eql('0.9.1')
@@ -162,7 +162,7 @@ describe PackageParser do
       expect( dep_17.outdated?() ).to be_falsey
 
       dep_18 = project.dependencies[18]
-      expect( dep_18.name ).to eql('eslint')
+      expect( dep_18.name ).to eql(product19[:name])
       expect( dep_18.version_label ).to eql('^0.24.0')
       expect( dep_18.version_requested ).to eql('0.24.1')
       expect( dep_18.version_current ).to eql('1.1.0')
@@ -170,7 +170,7 @@ describe PackageParser do
       expect( dep_18.outdated?() ).to be_truthy
 
       dep_19 = project.dependencies[19]
-      expect( dep_19.name ).to eql('inquirer')
+      expect( dep_19.name ).to eql(product20[:name])
       expect( dep_19.version_label ).to eql('^0.8.0')
       expect( dep_19.version_requested ).to eql('0.8.5')
       expect( dep_19.version_current ).to eql('0.9.0')


### PR DESCRIPTION
it solves the issue #92 in which `PackageParser.parse_requested_version` had not matching rules for git, http-tarball or filepath-tarball;

I had extra rules and updated specs for `PackageLockParser`, `PackageParser` and `ShrinkwarpParser` 