### PR TITLE
Fix project name bugs in  jspm parser; remove deprecations warnings on specs;

### DIFF
--- a/lib/versioneye/parsers/jspm_parser.rb
+++ b/lib/versioneye/parsers/jspm_parser.rb
@@ -92,12 +92,12 @@ class JspmParser < PackageParser
                    elsif proj_doc[:jspm].has_key?(:name)
                       proj_doc[:jspm][:name]
                    else
-                      "jspm_project_" + Time.now.to_s
+                      Time.now.to_s
                    end
 
     Project.new(
       parent_id: parent_id,
-      name: project_name.to_s,
+      name: 'jspm_' + project_name.to_s,
       project_type: Project::A_TYPE_JSPM,
       language: Product::A_LANGUAGE_NODEJS,
       description: proj_doc[:description],

--- a/lib/versioneye/parsers/jspm_parser.rb
+++ b/lib/versioneye/parsers/jspm_parser.rb
@@ -92,7 +92,7 @@ class JspmParser < PackageParser
                    elsif proj_doc[:jspm].has_key?(:name)
                       proj_doc[:jspm][:name]
                    else
-                      Time.now.to_s
+                     Time.now.to_i
                    end
 
     Project.new(

--- a/lib/versioneye/parsers/package_lock_parser.rb
+++ b/lib/versioneye/parsers/package_lock_parser.rb
@@ -15,9 +15,9 @@ class PackageLockParser < ShrinkwrapParser
     return nil if proj_doc.nil?
 
     project = init_project({
-      name: proj_doc[:name],
-      version: proj_doc[:version],
-      description: "package-lock.json"
+      'name'        => proj_doc[:name],
+      'version'     => proj_doc[:version],
+      'description' => "package-lock.json"
     })
 
     parse_dependency_items proj_doc, project

--- a/lib/versioneye/parsers/package_parser.rb
+++ b/lib/versioneye/parsers/package_parser.rb
@@ -320,12 +320,15 @@ class PackageParser < CommonParser
 
 
   def init_project( data )
+    project_name = data['name']
+    project_name ||= "npm_project_#{ Time.now.to_i}"
+
     project = Project.new
     project.project_type = Project::A_TYPE_NPM
     project.language     = Product::A_LANGUAGE_NODEJS
-    project.name         = data[:name]
-    project.description  = data[:description]
-    project.version      = data[:version]
+    project.name         = project_name
+    project.description  = data['description']
+    project.version      = data['version']
     project
   end
 

--- a/lib/versioneye/parsers/package_parser.rb
+++ b/lib/versioneye/parsers/package_parser.rb
@@ -53,7 +53,7 @@ class PackageParser < CommonParser
       log.info "going to parse child JSPM project dependencies"
       jspm_parser = JspmParser.new
       # JSPM parser expects that all the fields are keywords
-      symbolized_doc = JSON.parse(content, symbolize_names: true)
+      symbolized_doc = from_json content
       child_project = jspm_parser.parse_project_doc(symbolized_doc, project.id.to_s)
       if child_project
         project.dep_number += child_project.dependencies.size
@@ -63,6 +63,7 @@ class PackageParser < CommonParser
 
     project
   rescue => e
+    log.error "parse_content: failed to parse Package.json"
     log.error e.message
     log.error e.backtrace.join("\n")
     nil

--- a/lib/versioneye/parsers/shrinkwrap_parser.rb
+++ b/lib/versioneye/parsers/shrinkwrap_parser.rb
@@ -10,9 +10,9 @@ class ShrinkwrapParser < PackageParser
     return nil if proj_doc.nil?
 
     project = init_project({
-      name: proj_doc[:name],
-      version: proj_doc[:version],
-      description: "npm-shrinkwrap.json"
+      'name'        => proj_doc[:name],
+      'version'     => proj_doc[:version],
+      'description' => "npm-shrinkwrap.json"
     })
 
     parse_dependency_items proj_doc, project

--- a/spec/versioneye/parsers/package_parser_dev_spec.rb
+++ b/spec/versioneye/parsers/package_parser_dev_spec.rb
@@ -15,7 +15,7 @@ describe PackageParser do
     it "parse from https the file correctly" do
       parser = PackageParser.new
       project = parser.parse("https://s3.amazonaws.com/veye_test_env/package_dev.json")
-      project.should_not be_nil
+      expect( project ).not_to be_nil
     end
 
     it "parse from http the file correctly" do
@@ -35,93 +35,97 @@ describe PackageParser do
 
       parser = PackageParser.new
       project = parser.parse("https://s3.amazonaws.com/veye_test_env/package_dev.json")
-      project.should_not be_nil
-      project.dependencies.size.should eql(13)
+      expect( project ).not_to be_nil
+      expect( project.dependencies.size ).to eql(13)
 
       dep_01 = project.dependencies.first
-      dep_01.name.should eql("connect-redis")
-      dep_01.version_requested.should eql("1.3.0")
-      dep_01.version_current.should eql("1.3.0")
-      dep_01.comperator.should eql("=")
+      expect( dep_01.name ).to              eql(product1[:name])
+      expect( dep_01.version_requested ).to eql("1.3.0")
+      expect( dep_01.version_current ).to   eql("1.3.0")
+      expect( dep_01.comperator ).to        eql("=")
 
       dep_02 = project.dependencies[1]
-      dep_02.name.should eql("redis")
-      dep_02.version_requested.should eql("1.3.0")
-      dep_02.version_current.should eql("1.3.0")
-      dep_02.comperator.should eql("=")
+      expect( dep_02.name ).to              eql(product2[:name])
+      expect( dep_02.version_requested ).to eql("1.3.0")
+      expect( dep_02.version_current ).to   eql("1.3.0")
+      expect( dep_02.comperator ).to        eql("=")
 
       dep_03 = project.dependencies[2]
-      dep_03.name.should eql("memcache")
-      dep_03.version_requested.should eql("1.4.0")
-      dep_03.version_current.should eql("1.4.0")
-      dep_03.comperator.should eql("=")
+      expect( dep_03.name ).to              eql(product3[:name])
+      expect( dep_03.version_requested ).to eql("1.4.0")
+      expect( dep_03.version_current ).to   eql("1.4.0")
+      expect( dep_03.comperator ).to        eql("=")
 
       dep_04 = project.dependencies[3]
-      dep_04.name.should eql("mongo")
-      dep_04.version_requested.should eql("1.1.7")
-      dep_04.version_current.should eql("1.1.7")
-      dep_04.comperator.should eql("=")
+      expect( dep_04.name ).to              eql(product4[:name])
+      expect( dep_04.version_requested ).to eql("1.1.7")
+      expect( dep_04.version_current ).to   eql("1.1.7")
+      expect( dep_04.comperator ).to        eql("=")
 
       dep_05 = project.dependencies[4]
-      dep_05.name.should eql("mongoid")
-      dep_05.version_requested.should eql("1.1.7")
-      dep_05.version_current.should eql("1.1.7")
-      dep_05.comperator.should eql("=")
+      expect( dep_05.name ).to              eql(product5[:name])
+      expect( dep_05.version_requested ).to eql("1.1.7")
+      expect( dep_05.version_current ).to   eql("1.1.7")
+      expect( dep_05.comperator ).to        eql("=")
 
       dep_06 = project.dependencies[5]
-      dep_06.name.should eql("express")
-      dep_06.version_requested.should eql("2.4.7")
-      dep_06.version_current.should eql("2.4.7")
-      dep_06.comperator.should eql("=")
+      expect( dep_06.name ).to              eql(product6[:name])
+      expect( dep_06.version_requested ).to eql("2.4.7")
+      expect( dep_06.version_current ).to   eql("2.4.7")
+      expect( dep_06.comperator ).to        eql("=")
 
       dep_07 = project.dependencies[6]
-      dep_07.name.should eql("fs-ext")
-      dep_07.version_requested.should eql("0.2.7")
-      dep_07.version_current.should eql("2.4.7")
-      dep_07.comperator.should eql("=")
+      expect( dep_07.name ).to              eql(product7[:name])
+      expect( dep_07.version_requested ).to eql("0.2.7")
+      expect( dep_07.version_current ).to   eql("2.4.7")
+      expect( dep_07.comperator ).to        eql("=")
 
       dep_08 = project.dependencies[7]
-      dep_08.name.should eql("jade")
-      dep_08.version_requested.should eql("0.2.7")
-      dep_08.version_current.should eql("2.4.7")
-      dep_08.comperator.should eql("~")
+      expect( dep_08.name ).to              eql(product8[:name])
+      expect( dep_08.version_requested ).to eql("0.2.7")
+      expect( dep_08.version_current ).to   eql("2.4.7")
+      expect( dep_08.comperator ).to        eql("~")
 
       dep_09 = project.dependencies[8]
-      dep_09.name.should eql("mailer")
-      dep_09.version_requested.should eql("0.6.9")
-      dep_09.version_current.should eql("0.7.0")
-      dep_09.comperator.should eql("=")
+      expect( dep_09.name ).to              eql(product9[:name])
+      expect( dep_09.version_requested ).to eql("0.6.9")
+      expect( dep_09.version_current ).to   eql("0.7.0")
+      expect( dep_09.comperator ).to        eql("=")
 
       dep_10 = project.dependencies[9]
-      dep_10.name.should eql("markdown")
-      dep_10.version_requested.should eql("0.2.0")
-      dep_10.version_current.should eql("0.4.0")
-      dep_10.comperator.should eql("<")
+      expect( dep_10.name ).to              eql(product10[:name])
+      expect( dep_10.version_requested ).to eql("0.2.0")
+      expect( dep_10.version_current ).to   eql("0.4.0")
+      expect( dep_10.comperator ).to        eql("<")
 
       dep_11 = project.dependencies[10]
-      dep_11.name.should eql("mu2")
-      dep_11.version_requested.should eql("0.6.0")
-      dep_11.version_current.should eql("0.6.0")
-      dep_11.comperator.should eql(">")
+      expect( dep_11.name ).to              eql(product11[:name])
+      expect( dep_11.version_requested ).to eql("0.6.0")
+      expect( dep_11.version_current ).to   eql("0.6.0")
+      expect( dep_11.comperator ).to        eql(">")
 
       dep_12 = project.dependencies[11]
-      dep_12.name.should eql("pg")
-      dep_12.version_requested.should eql("0.6.6")
-      dep_12.version_current.should eql("0.6.6")
-      dep_12.comperator.should eql(">=")
+      expect( dep_12.name ).to              eql(product12[:name])
+      expect( dep_12.version_requested ).to eql("0.6.6")
+      expect( dep_12.version_current ).to   eql("0.6.6")
+      expect( dep_12.comperator ).to        eql(">=")
 
       dep_13 = project.dependencies[12]
-      dep_13.name.should eql("pg_connect")
-      dep_13.version_requested.should eql("0.6.9")
-      dep_13.version_current.should eql("0.6.9")
-      dep_13.comperator.should eql("<=")
+      expect( dep_13.name ).to              eql(product13[:name])
+      expect( dep_13.version_requested ).to eql("0.6.9")
+      expect( dep_13.version_current ).to   eql("0.6.9")
+      expect( dep_13.comperator ).to        eql("<=")
 
     end
 
   end
 
   def create_product(name, prod_key, version, versions = nil )
-    product = Product.new({ :language => Product::A_LANGUAGE_NODEJS, :prod_type => Project::A_TYPE_NPM })
+    product = Product.new({
+      :language => Product::A_LANGUAGE_NODEJS,
+      :prod_type => Project::A_TYPE_NPM
+    })
+
     product.name = name
     product.prod_key = prod_key
     product.version = version

--- a/spec/versioneye/parsers/package_parser_run_dev_spec.rb
+++ b/spec/versioneye/parsers/package_parser_run_dev_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe PackageParser do
+  let(:parser){ PackageParser.new }
+  let(:test_file_url){ "https://s3.amazonaws.com/veye_test_env/package_run_dev.json"}
 
   before(:each) do
     Product.delete_all
@@ -13,9 +15,8 @@ describe PackageParser do
   describe "parse" do
 
     it "parse from https the file correctly" do
-      parser = PackageParser.new
-      project = parser.parse("https://s3.amazonaws.com/veye_test_env/package_run_dev.json")
-      project.should_not be_nil
+      project = parser.parse test_file_url
+      expect( project ).not_to be_nil
     end
 
     it "parse from http the file correctly" do
@@ -33,88 +34,87 @@ describe PackageParser do
       product12 = create_product('pg'           , 'pg'        , '0.6.6', ['0.5.0' , '0.6.1' ] )
       product13 = create_product('pg_connect'   , 'pg_connect', '0.6.9', ['0.5.0' , '0.6.1' ] )
 
-      parser = PackageParser.new
-      project = parser.parse("https://s3.amazonaws.com/veye_test_env/package_run_dev.json")
-      project.should_not be_nil
-      project.dependencies.size.should eql(13)
+      project = parser.parse test_file_url
+      expect( project ).not_to be_nil
+      expect( project.dependencies.size ).to eql(13)
 
       dep_01 = project.dependencies.first
-      dep_01.name.should eql("connect-redis")
-      dep_01.version_requested.should eql("1.3.0")
-      dep_01.version_current.should eql("1.3.0")
-      dep_01.comperator.should eql("=")
+      expect( dep_01.name ).to              eql(product1[:name])
+      expect( dep_01.version_requested ).to eql("1.3.0")
+      expect( dep_01.version_current ).to   eql("1.3.0")
+      expect( dep_01.comperator ).to        eql("=")
 
       dep_03 = project.dependencies[1]
-      dep_03.name.should eql("memcache")
-      dep_03.version_requested.should eql("1.4.0")
-      dep_03.version_current.should eql("1.4.0")
-      dep_03.comperator.should eql("=")
+      expect( dep_03.name ).to              eql(product3[:name])
+      expect( dep_03.version_requested ).to eql("1.4.0")
+      expect( dep_03.version_current ).to   eql("1.4.0")
+      expect( dep_03.comperator ).to        eql("=")
 
       dep_04 = project.dependencies[2]
-      dep_04.name.should eql("mongo")
-      dep_04.version_requested.should eql("1.1.7")
-      dep_04.version_current.should eql("1.1.7")
-      dep_04.comperator.should eql("=")
+      expect( dep_04.name ).to              eql(product4[:name])
+      expect( dep_04.version_requested ).to eql("1.1.7")
+      expect( dep_04.version_current ).to   eql("1.1.7")
+      expect( dep_04.comperator ).to        eql("=")
 
       dep_05 = project.dependencies[3]
-      dep_05.name.should eql("mongoid")
-      dep_05.version_requested.should eql("1.1.7")
-      dep_05.version_current.should eql("1.1.7")
-      dep_05.comperator.should eql("=")
+      expect( dep_05.name ).to              eql(product5[:name])
+      expect( dep_05.version_requested ).to eql("1.1.7")
+      expect( dep_05.version_current ).to   eql("1.1.7")
+      expect( dep_05.comperator ).to        eql("=")
 
       dep_06 = project.dependencies[4]
-      dep_06.name.should eql("express")
-      dep_06.version_requested.should eql("2.4.7")
-      dep_06.version_current.should eql("2.4.7")
-      dep_06.comperator.should eql("=")
+      expect( dep_06.name ).to              eql(product6[:name])
+      expect( dep_06.version_requested ).to eql("2.4.7")
+      expect( dep_06.version_current ).to   eql("2.4.7")
+      expect( dep_06.comperator ).to        eql("=")
 
       dep_07 = project.dependencies[5]
-      dep_07.name.should eql("fs-ext")
-      dep_07.version_requested.should eql("0.2.7")
-      dep_07.version_current.should eql("2.4.7")
-      dep_07.comperator.should eql("=")
+      expect( dep_07.name ).to              eql(product7[:name])
+      expect( dep_07.version_requested ).to eql("0.2.7")
+      expect( dep_07.version_current ).to   eql("2.4.7")
+      expect( dep_07.comperator ).to        eql("=")
 
       dep_08 = project.dependencies[6]
-      dep_08.name.should eql("jade")
-      dep_08.version_requested.should eql("0.2.7")
-      dep_08.version_current.should eql("2.4.7")
-      dep_08.comperator.should eql("~")
+      expect( dep_08.name ).to              eql(product8[:name])
+      expect( dep_08.version_requested ).to eql("0.2.7")
+      expect( dep_08.version_current ).to   eql("2.4.7")
+      expect( dep_08.comperator ).to        eql("~")
 
       dep_09 = project.dependencies[7]
-      dep_09.name.should eql("mailer")
-      dep_09.version_requested.should eql("0.6.9")
-      dep_09.version_current.should eql("0.7.0")
-      dep_09.comperator.should eql("=")
+      expect( dep_09.name ).to              eql(product9[:name])
+      expect( dep_09.version_requested ).to eql("0.6.9")
+      expect( dep_09.version_current ).to   eql("0.7.0")
+      expect( dep_09.comperator ).to        eql("=")
 
       dep_10 = project.dependencies[8]
-      dep_10.name.should eql("markdown")
-      dep_10.version_requested.should eql("0.2.0")
-      dep_10.version_current.should eql("0.4.0")
-      dep_10.comperator.should eql("<")
+      expect( dep_10.name ).to              eql(product10[:name])
+      expect( dep_10.version_requested ).to eql("0.2.0")
+      expect( dep_10.version_current ).to   eql("0.4.0")
+      expect( dep_10.comperator ).to        eql("<")
 
       dep_11 = project.dependencies[9]
-      dep_11.name.should eql("mu2")
-      dep_11.version_requested.should eql("0.6.0")
-      dep_11.version_current.should eql("0.6.0")
-      dep_11.comperator.should eql(">")
+      expect( dep_11.name ).to              eql(product11[:name])
+      expect( dep_11.version_requested ).to eql("0.6.0")
+      expect( dep_11.version_current ).to   eql("0.6.0")
+      expect( dep_11.comperator ).to        eql(">")
 
       dep_12 = project.dependencies[10]
-      dep_12.name.should eql("pg")
-      dep_12.version_requested.should eql("0.6.6")
-      dep_12.version_current.should eql("0.6.6")
-      dep_12.comperator.should eql(">=")
+      expect( dep_12.name ).to              eql(product12[:name])
+      expect( dep_12.version_requested ).to eql("0.6.6")
+      expect( dep_12.version_current ).to   eql("0.6.6")
+      expect( dep_12.comperator ).to        eql(">=")
 
       dep_13 = project.dependencies[11]
-      dep_13.name.should eql("pg_connect")
-      dep_13.version_requested.should eql("0.6.9")
-      dep_13.version_current.should eql("0.6.9")
-      dep_13.comperator.should eql("<=")
+      expect( dep_13.name ).to              eql(product13[:name])
+      expect( dep_13.version_requested ).to eql("0.6.9")
+      expect( dep_13.version_current ).to   eql("0.6.9")
+      expect( dep_13.comperator ).to        eql("<=")
 
       dep_02 = project.dependencies[12]
-      dep_02.name.should eql("redis")
-      dep_02.version_requested.should eql("1.3.0")
-      dep_02.version_current.should eql("1.3.0")
-      dep_02.comperator.should eql("=")
+      expect( dep_02.name ).to              eql(product2[:name])
+      expect( dep_02.version_requested ).to eql("1.3.0")
+      expect( dep_02.version_current ).to   eql("1.3.0")
+      expect( dep_02.comperator ).to        eql("=")
 
     end
 

--- a/spec/versioneye/parsers/package_parser_tilde_spec.rb
+++ b/spec/versioneye/parsers/package_parser_tilde_spec.rb
@@ -1,13 +1,14 @@
 require 'spec_helper'
 
 describe PackageParser do
+  let(:parser){ PackageParser.new }
+  let(:test_file_url){ 'https://s3.amazonaws.com/veye_test_env/npm_1/package.json'}
 
   describe "parse" do
 
     it "parse from https the file correctly" do
-      parser = PackageParser.new
-      project = parser.parse('https://s3.amazonaws.com/veye_test_env/npm_1/package.json')
-      project.should_not be_nil
+      project = parser.parse test_file_url
+      expect( project ).not_to be_nil
     end
 
     it "parse from http the file correctly" do
@@ -17,42 +18,41 @@ describe PackageParser do
       product3 = create_product('gcloud'   , 'gcloud'   , '0.2.0', ['0.20.0' , '0.21.0', '0.22.0', '0.23.0', '0.24.0', '0.24.1', '0.25.0', '0.25.1', '0.26.0', '0.26.1' ] )
       product4 = create_product('express'  , 'express'   , '4.13.3', ['4.0.0' , '4.1.0', '4.13.3' ] )
 
-      parser = PackageParser.new
-      project = parser.parse('https://s3.amazonaws.com/veye_test_env/npm_1/package.json')
-      project.should_not be_nil
-      project.dependencies.size.should eql(4)
+      project = parser.parse test_file_url
+      expect( project ).not_to be_nil
+      expect( project.dependencies.size ).to eql(4)
 
       dep_1 = project.dependencies[0]
-      dep_1.name.should eql('eslint')
-      dep_1.version_label.should eql('^1.0.0')
-      dep_1.version_requested.should eql('1.1.0')
-      dep_1.version_current.should eql('1.1.0')
-      dep_1.comperator.should eql('^')
-      dep_1.outdated?().should be_falsey
+      expect( dep_1.name ).to               eql(product1[:name])
+      expect( dep_1.version_label ).to      eql('^1.0.0')
+      expect( dep_1.version_requested ).to  eql('1.1.0')
+      expect( dep_1.version_current ).to    eql('1.1.0')
+      expect( dep_1.comperator ).to         eql('^')
+      expect( dep_1.outdated? ).to          be_falsey
 
       dep_2 = project.dependencies[1]
-      dep_2.name.should eql('inquirer')
-      dep_2.version_label.should eql('^0.8.0')
-      dep_2.version_requested.should eql('0.8.5')
-      dep_2.version_current.should eql('0.9.0')
-      dep_2.comperator.should eql('^')
-      dep_2.outdated?().should be_truthy
+      expect( dep_2.name ).to               eql(product2[:name])
+      expect( dep_2.version_label ).to      eql('^0.8.0')
+      expect( dep_2.version_requested ).to  eql('0.8.5')
+      expect( dep_2.version_current ).to    eql('0.9.0')
+      expect( dep_2.comperator ).to         eql('^')
+      expect( dep_2.outdated? ).to          be_truthy
 
       dep_3 = project.dependencies[2]
-      dep_3.name.should eql('gcloud')
-      dep_3.version_label.should eql('^0.23')
-      dep_3.version_requested.should eql('0.23.0')
-      dep_3.version_current.should eql('0.26.1')
-      dep_3.comperator.should eql('^')
-      dep_3.outdated?().should be_truthy
+      expect( dep_3.name ).to               eql(product3[:name])
+      expect( dep_3.version_label ).to      eql('^0.23')
+      expect( dep_3.version_requested ).to  eql('0.23.0')
+      expect( dep_3.version_current ).to    eql('0.26.1')
+      expect( dep_3.comperator ).to         eql('^')
+      expect( dep_3.outdated? ).to          be_truthy
 
       dep_4 = project.dependencies[3]
-      dep_4.name.should eql('express')
-      dep_4.version_label.should eql('~4.*')
-      dep_4.version_requested.should eql('4.13.3')
-      dep_4.version_current.should eql('4.13.3')
-      dep_4.comperator.should eql('~')
-      dep_4.outdated?().should be_falsey
+      expect( dep_4.name ).to               eql(product4[:name])
+      expect( dep_4.version_label ).to      eql('~4.*')
+      expect( dep_4.version_requested ).to  eql('4.13.3')
+      expect( dep_4.version_current ).to    eql('4.13.3')
+      expect( dep_4.comperator ).to         eql('~')
+      expect( dep_4.outdated? ).to          be_falsey
     end
 
   end


### PR DESCRIPTION
Hi,

i debugged the `JspmParser` with some projects files from Github and found 2possible bugs:

* when no project.name, then it fails to concanate string and integer value of current time
* when parent project has same name as child project then it doesnt show up on web interface

Also removed deprecation warnings from all the specs of PackageParser.