### PR TITLE
fix #101 - updating package project didnt add childrens from updated project

### DIFF
--- a/lib/versioneye/models/project.rb
+++ b/lib/versioneye/models/project.rb
@@ -355,6 +355,14 @@ class Project < Versioneye::Model
 
     self.overwrite_dependencies( new_project.projectdependencies )
 
+    # move children project and abandon the previous kids
+    # needed for JSPM projects that are children of Package project
+    self.children.to_a.each {|p| p.delete }
+    new_project.children.to_a.each do |child_proj|
+      child_proj.update(parent_id: self.ids)
+      child_proj.save
+    end
+
     self.save
   end
 

--- a/lib/versioneye/services/project_parse_service.rb
+++ b/lib/versioneye/services/project_parse_service.rb
@@ -12,7 +12,8 @@ class ProjectParseService < Versioneye::Service
 
   def self.parser_for file_name
     type   = ProjectService.type_by_filename file_name
-    parser = ParserStrategy.parser_for type, file_name
+
+    ParserStrategy.parser_for type, file_name
   end
 
 

--- a/lib/versioneye/services/sync_service.rb
+++ b/lib/versioneye/services/sync_service.rb
@@ -393,6 +393,9 @@ class SyncService < Versioneye::Service
     def self.parsed_date released_at
       DateTime.parse( released_at )
     rescue => e
+      log.error "parsed_date: failed to parse `#{released_at}`"
+      log.error e.message
+      log.error e.backtrace.join('\n')
       nil
     end
 

--- a/spec/fixtures/files/npm/package_with_jspm.json
+++ b/spec/fixtures/files/npm/package_with_jspm.json
@@ -1,0 +1,28 @@
+{
+  "name": "backbone-parse-es6",
+  "version": "0.1.0",
+  "homepage": "https://github.com/typhonjs-backbone-parse/backbone-parse-es6/",
+  "description": "An extension to Backbone-ES6 adding support for the Parse 1.6+ SDK.",
+  "license": "MPL-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/typhonjs-backbone-parse/backbone-parse-es6.git"
+  },
+  "bugs": {
+    "url": "https://github.com/typhonjs-backbone-parse/backbone-parse-es6/issues"
+  },
+  "jspm": {
+    "main": "src/ModuleRuntime.js",
+    "dependencies": {
+      "backbone-es6": "github:typhonjs-backbone/backbone-es6@master",
+      "underscore": "npm:underscore@^1.0.0"
+    },
+    "devDependencies": {
+      "babel": "npm:babel-core@^5.0.0"
+    }
+  },
+  "devDependencies": {
+    "gulp": "^3.0.0",
+    "jspm": "^0.16.0"
+  }
+}

--- a/spec/fixtures/files/npm/package_without_jspm.json
+++ b/spec/fixtures/files/npm/package_without_jspm.json
@@ -1,0 +1,18 @@
+{
+  "name": "backbone-parse-es6",
+  "version": "0.1.0",
+  "homepage": "https://github.com/typhonjs-backbone-parse/backbone-parse-es6/",
+  "description": "An extension to Backbone-ES6 adding support for the Parse 1.6+ SDK.",
+  "license": "MPL-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/typhonjs-backbone-parse/backbone-parse-es6.git"
+  },
+  "bugs": {
+    "url": "https://github.com/typhonjs-backbone-parse/backbone-parse-es6/issues"
+  },
+  "devDependencies": {
+    "gulp": "^3.0.0",
+    "jspm": "^0.16.0"
+  }
+}

--- a/spec/versioneye/updater/common_updater_spec.rb
+++ b/spec/versioneye/updater/common_updater_spec.rb
@@ -1,27 +1,60 @@
 require 'spec_helper'
 
 describe CommonUpdater do
+  let(:content_without_jspm){ File.read 'spec/fixtures/files/npm/package_without_jspm.json' }
+  let(:content_with_jspm){ File.read 'spec/fixtures/files/npm/package_with_jspm.json' }
+
+  let(:user){ UserFactory.create_new }
+  let(:parser){ PackageParser.new }
 
   describe 'update_old_with_new' do
 
     it 'updates old project with new values, clears the cache and dont send email' do
       ActionMailer::Base.deliveries.clear
-      user = UserFactory.create_new
+
       old_project = ProjectFactory.default user, 10
       new_project = ProjectFactory.default user, 11
 
       CommonUpdater.cache.set( old_project.id.to_s, "out-of-date", 21600) # TTL = 6.hour
-      CommonUpdater.cache.get( old_project.id.to_s).should_not be_nil
+      expect( CommonUpdater.cache.get( old_project.id.to_s) ).not_to be_nil
 
       CommonUpdater.new.update_old_with_new old_project, new_project
 
       # Expect that cache for project badge is cleared
-      CommonUpdater.cache.get( old_project.id.to_s).should be_nil
+      expect( CommonUpdater.cache.get( old_project.id.to_s) ).to be_nil
 
       # Epcect that 0 emails are send
-      ActionMailer::Base.deliveries.size.should == 0
+      expect( ActionMailer::Base.deliveries.size ).to eq(0)
     end
 
+  end
+
+
+  describe 'updating existing Package project with a project with JSPM' do
+
+    it 'should create attach child project to updated project' do
+      old_project = parser.parse_content content_without_jspm
+      old_project[:user_id] = user.ids
+      expect(old_project.save).to be_truthy
+      expect(old_project).not_to be_nil
+      expect(old_project.dep_number).to eq(2)
+      expect(old_project.children.to_a.size).to eq(0)
+
+      new_project = parser.parse_content content_with_jspm
+      new_project[:user_id] = user.ids
+      expect(new_project).not_to be_nil
+      expect(new_project.dep_number).to eq(5)
+      expect(new_project.children.to_a.size).to eq(1)
+
+      # move new project into old project
+      CommonUpdater.new.update_old_with_new old_project, new_project
+      old_project.reload
+      expect(old_project).not_to be_nil
+      expect(old_project.dep_number).to eq(5)
+      expect(old_project.children.to_a.size).to eq(1)
+
+
+    end
   end
 
 end


### PR DESCRIPTION

Hi,

i updated `CommonUpdater.update_old_with_new` so that it could bring JSPM children from new project to old project.

i also removed deprecation warnings on `common_updater_spec.rb` and add test case for my update.
