### PR TITLE
fix #97 - use fixed version as default value;

### DIFF
--- a/lib/versioneye/parsers/csproj_parser.rb
+++ b/lib/versioneye/parsers/csproj_parser.rb
@@ -16,11 +16,16 @@ class CsprojParser < NugetParser
   def parse_dependency(pkg_node)
     prod_key = pkg_node.attr('Include').to_s.strip
     version_label = if pkg_node.has_attribute?('Version')
-                      pkg_node.attr('Version').to_s.strip
+                      pkg_node.attr('Version').to_s
                     else
                       #version wasnt specified as attribute, check child nodes
                       pkg_node.xpath('//Version').text
                     end
+    version_label = version_label.to_s.strip
+    # solves issue #97 - "1.2.3" is default equal to "[1.2.3]"
+    if version_label[0] != '(' and version_label[0] != '['
+      version_label = "[#{version_label}]"
+    end
 
     init_dependency(prod_key, version_label, nil, Dependency::A_SCOPE_COMPILE)
   end

--- a/spec/versioneye/parsers/csproj_parser_spec.rb
+++ b/spec/versioneye/parsers/csproj_parser_spec.rb
@@ -41,7 +41,7 @@ describe 'CsprojParser' do
       expect(deps[1][:language]).to eq(product2[:language])
       expect(deps[1][:prod_key]).to eq(product2[:prod_key])
       expect(deps[1][:name]).to eq(product2[:name])
-      expect(deps[1][:version_label]).to eq('1.1.0')
+      expect(deps[1][:version_label]).to eq('[1.1.0]')
 
     end
   end
@@ -78,8 +78,8 @@ describe 'CsprojParser' do
       expect(dep2[:language]).to eq(product2[:language])
       expect(dep2[:scope]).to eq(Dependency::A_SCOPE_COMPILE)
       expect(dep2[:version_requested]).to eq('1.1.0')
-      expect(dep2[:version_label]).to eq('1.1.0')
-      expect(dep2[:comperator]).to eq('>=')
+      expect(dep2[:version_label]).to eq('[1.1.0]')
+      expect(dep2[:comperator]).to eq('=')
       expect(dep2[:outdated]).to be_falsey
 
     end


### PR DESCRIPTION
Hi,

i added custom workaround for the `CSProjParser`, it turns every version which doesnt start with the symbols `(` or `[` into `==` version range.