### PR TITLE
Fix: when module doesnt exists, check it from perl submodules;

### DIFF
--- a/lib/versioneye/models/product.rb
+++ b/lib/versioneye/models/product.rb
@@ -196,8 +196,9 @@ class Product < Versioneye::Model
         prod_type: Project::A_TYPE_CPAN,
         prod_key: 'perl'
       ).first
-
-      product = perl_db if perl_db.modules.to_a.include?(module_id)
+      if perl_db and perl_db[:modules].to_a.include?(module_id)
+        product = perl_db
+      end
     end
 
     product

--- a/lib/versioneye/models/product.rb
+++ b/lib/versioneye/models/product.rb
@@ -140,7 +140,10 @@ class Product < Versioneye::Model
 
     product = Product.find_by_lang_key( lang, key )
     product = Product.find_by_lang_key( lang, key.downcase ) if product.nil?
-    product = Product.where(:language => lang, :prod_key_dc => key.downcase).first if ( product.nil? && lang.eql?( A_LANGUAGE_NODEJS ) )
+    if ( product.nil? && lang.eql?( A_LANGUAGE_NODEJS ) )
+      product = Product.where(:language => lang, :prod_key_dc => key.downcase).first
+    end
+
     product
   end
 
@@ -179,7 +182,6 @@ class Product < Versioneye::Model
       :prod_key.in => [double_id, single_id]
     ).first
 
-
     # try to find product by distribution name
     product ||= Product.where(
       language: Product::A_LANGUAGE_PERL,
@@ -187,6 +189,16 @@ class Product < Versioneye::Model
       name_downcase: module_id.downcase
     ).first
 
+    #finally look from the core modules of perl
+    if product.nil?
+      perl_db = Product.where(
+        language: Product::A_LANGUAGE_PERL,
+        prod_type: Project::A_TYPE_CPAN,
+        prod_key: 'perl'
+      ).first
+
+      product = perl_db if perl_db.modules.to_a.include?(module_id)
+    end
 
     product
   end

--- a/spec/versioneye/models/product_spec.rb
+++ b/spec/versioneye/models/product_spec.rb
@@ -292,11 +292,24 @@ describe Product do
     )
   }
 
+  let(:cpan_perl){
+    Product.new(
+      language: Product::A_LANGUAGE_PERL,
+      prod_type: Project::A_TYPE_CPAN,
+      prod_key: 'perl',
+      name: 'perl',
+      name_downcase: 'perl',
+      version: '5.26',
+      modules: ['File::Basename', 'Sys::Hostname']
+    )
+  }
+
 
   describe "fetch_cpan" do
     before do
       cpan_prod1.save
       cpan_prod2.save
+      cpan_perl.save
     end
 
     it "finds match by parent module name" do
@@ -327,6 +340,17 @@ describe Product do
       expect(prod[:prod_type]).to eq(cpan_prod1[:prod_type])
       expect(prod[:prod_key]).to eq(cpan_prod1[:prod_key])
       expect(prod[:name]).to eq(cpan_prod1[:name])
+    end
+
+    it "finds match from perl submodule" do
+      prod = Product.fetch_cpan('Sys::Hostname')
+
+      expect(prod).not_to be_nil
+      expect(prod[:language]).to eq(cpan_perl[:language])
+      expect(prod[:prod_type]).to eq(cpan_perl[:prod_type])
+      expect(prod[:prod_key]).to eq(cpan_perl[:prod_key])
+      expect(prod[:name]).to eq(cpan_perl[:name])
+
     end
   end
 


### PR DESCRIPTION
It solves issue with unknown packages from here:https://www.versioneye.com/perl/DateTime::TimeZone/2.13 

All the unknown packages on that page are actually submodules of the `perl/perl` package.
I just added additional fallback method into the `Product.fetch_cpan` function.