### PR TITLE
solves #117 - Add support npm tags

### DIFF
--- a/lib/versioneye/models/version.rb
+++ b/lib/versioneye/models/version.rb
@@ -8,6 +8,7 @@ class Version < Versioneye::Model
   field :downloads      , type: Integer
   field :pom            , type: String # maven specific
   field :tag            , type: String # biicode specific - git tag string
+  field :tags           , type: Array, default: [] # distribution tags for NPM(latest, next, etc)
   field :status         , type: String # Userd in biitcode & Nuget - [STABLE, DEV, PRERELEASE]
 
   field :release_id     , type: String # CPAN specific, it's unique id to get version release details

--- a/lib/versioneye/parsers/package_parser.rb
+++ b/lib/versioneye/parsers/package_parser.rb
@@ -452,7 +452,7 @@ class PackageParser < CommonParser
 
   def semver?(version_label)
     res = SemVer.parse(version_label.to_s)
-    true if res
+    (res.nil? == false)
   rescue
     false
   end

--- a/spec/versioneye/parsers/package_parser_spec.rb
+++ b/spec/versioneye/parsers/package_parser_spec.rb
@@ -36,7 +36,34 @@ describe PackageParser do
       expect(dep1[:version_requested]).to eq('1.3.0')
       expect(dep1[:version_label]).to eq('1.3.0')
       expect(dep1[:comperator]).to eq('=')
+    end
 
+    it "returns correct tagged stable version" do
+      product1.versions = []
+      product1.versions << Version.new(version: '0.9.0', tags: ['next'])
+      product1.versions << Version.new(version: '1.0.0', tags: ['next'])
+      product1.save
+
+      parser.parse_requested_version('next', dep1, product1)
+      expect(dep1).not_to be_nil
+      expect(dep1[:version_requested]).to eq('1.0.0')
+      expect(dep1[:version_label]).to eq('next')
+      expect(dep1[:comperator]).to eq('=')
+    end
+
+    # issue #117 , product: `react-router-redux`
+    it "returns correct tagged unstable version" do
+      product1.versions = []
+      product1.versions << Version.new(version: '5.0.0-alpha.6', tags: ['next'])
+      product1.versions << Version.new(version: '5.0.0-alpha.5', tags: ['next'])
+      product1.versions << Version.new(version: '5.0.0-alpha.4', tags: ['next'])
+      product1.save
+
+      parser.parse_requested_version('next', dep1, product1)
+      expect(dep1).not_to be_nil
+      expect(dep1[:version_requested]).to eq('5.0.0-alpha.6')
+      expect(dep1[:version_label]).to eq('next')
+      expect(dep1[:comperator]).to eq('=')
     end
   end
 
@@ -64,7 +91,11 @@ describe PackageParser do
       product12 = create_product('pg'           , 'pg'           , '0.6.6', ['0.5.0' , '0.6.1' ] )
       product13 = create_product('pg_connect'   , 'pg_connect'   , '0.6.9', ['0.5.0' , '0.6.1' ] )
 
-      product14 = create_product('mocha'        , 'mocha'        , '1.16.2', ['1.0.0' , '1.16.0', '1.16.2' ] )
+      product14 = create_product('mocha'        , 'mocha'        , '1.16.2', ['1.0.0' , '1.16.0'] )
+      product14.versions << Version.new(version: '1.15.0', tags: ['latest'])
+      product14.versions << Version.new(version: '1.16.2', tags: ['latest'])
+      product14.save
+
       product15 = create_product('bruno'        , 'bruno'        , '1.12.1', ['1.0.0' , '1.12.0', '1.12.1' ] )
       product16 = create_product('gulp'         , 'gulp'         , '1.12.1', ['1.0.0' , '1.12.0', '1.12.1' ] )
 


### PR DESCRIPTION
Hi, 

this PR ables to look up a package version by NPM dist-tag.
Behaviour of `latest` tag stays same => it only takes latest stable version.
For other dist-tags, it will take the latest unstable version.


