### PR TITLE
Add parsers for CPAN Meta.json and Meta.yml files

### DIFF
--- a/lib/versioneye/parsers/common_parser.rb
+++ b/lib/versioneye/parsers/common_parser.rb
@@ -250,6 +250,8 @@ class CommonParser
 
   def self.cpan_file?(filename)
     return true if /cpanfile\z/i.match?(filename)
+    return true if /META\.json\z/i.match?(filename)
+    return true if /META\.ya?ml\z/i.match?(filename)
 
     return false
   end

--- a/lib/versioneye/parsers/meta_json_parser.rb
+++ b/lib/versioneye/parsers/meta_json_parser.rb
@@ -1,5 +1,6 @@
 require 'versioneye/parsers/common_parser'
 
+# a parser for CPAN meta.json files
 class MetaJsonParser < CpanParser
 
   def parse_content(meta_txt, token = nil)
@@ -18,8 +19,8 @@ class MetaJsonParser < CpanParser
     project.dep_number = project.projectdependencies.size
     project
   rescue => e
-    log.error "MetaJsonParser: error in parse_content. #{e.message} \n #{meta_doc}"
-    log.error e.backtrace.join('\n')
+    logger.error "MetaJsonParser: error in parse_content. #{e.message} \n #{meta_doc}"
+    logger.error e.backtrace.join('\n')
     nil
   end
 

--- a/lib/versioneye/parsers/meta_json_parser.rb
+++ b/lib/versioneye/parsers/meta_json_parser.rb
@@ -1,0 +1,64 @@
+require 'versioneye/parsers/common_parser'
+
+class MetaJsonParser < CpanParser
+
+  def parse_content(meta_txt, token = nil)
+    return if meta_txt.to_s.empty?
+
+    meta_doc = from_json meta_txt
+    if meta_doc.nil?
+      logger.error "parse_content: empty meta.json document"
+      return
+    end
+
+    project = init_project 'meta.json project'
+    deps = parse_dependencies(meta_doc[:prereqs])
+    save_project_dependencies(project, deps)
+
+    project.dep_number = project.projectdependencies.size
+    project
+  rescue => e
+    log.error "MetaJsonParser: error in parse_content. #{e.message} \n #{meta_doc}"
+    log.error e.backtrace.join('\n')
+    nil
+  end
+
+  # takes map of CPAN required packages and turns into list of Dependency
+  def parse_dependencies(reqs_doc)
+    deps = []
+
+    if reqs_doc.nil? or reqs_doc.empty?
+      logger.error "parse_dependencies: meta_doc has no data in :prereqs field"
+      return deps
+    end
+
+    if reqs_doc.is_a?(Hash) == false
+      logger.error "parse_dependencies: the doc of requirements is not Hashmap"
+      return deps
+    end
+
+    reqs_doc.each_pair do |scope, req_group|
+      # merge requires, recommends, suggests and etc groups into one
+      prods = req_group.values.to_a.reduce({}) {|acc, x| acc.merge!(x); acc}
+
+      # initialize a Projectdependency models for each product
+      prods.to_a.each do |prod_key, version_label|
+        deps << init_dependency(prod_key.to_s, version_label.to_s, scope.to_s)
+      end
+    end
+
+    deps
+  end
+
+  def init_dependency(prod_key, version_label, scope)
+    Projectdependency.new(
+      language: Product::A_LANGUAGE_PERL,
+      prod_key: prod_key,
+      name: prod_key,
+      version_label: version_label,
+      scope: scope.to_s.downcase
+    )
+  end
+
+
+end

--- a/lib/versioneye/parsers/meta_yaml_parser.rb
+++ b/lib/versioneye/parsers/meta_yaml_parser.rb
@@ -1,0 +1,82 @@
+require 'versioneye/parsers/common_parser'
+
+# a parser for CPAN meta.yaml files
+class MetaYamlParser < CpanParser
+
+  def parse_content(meta_txt, token = nil)
+    return if meta_txt.to_s.empty?
+
+    meta_doc = from_yaml meta_txt
+    if meta_doc.nil?
+      logger.error "parse_content: unparseable meta.yml document"
+      return
+    end
+
+    project = init_project 'meta.yml project'
+    deps = parse_dependencies(meta_doc)
+    save_project_dependencies(project, deps)
+
+    project.dep_number = project.projectdependencies.size
+    project
+  rescue => e
+    logger.error "MetaYamlParser: error in parse_content"
+    logger.error "\treason: #{e.message}"
+    logger.error e.backtrace.join('\n')
+    nil
+  end
+
+  # extracts dependency info from project file and initializes Dependency models
+  def parse_dependencies(meta_doc)
+    deps = []
+
+    if meta_doc.nil? or meta_doc.empty?
+      logger.error "parse_dependencies: no content"
+      return deps
+    end
+
+    # required dependencies
+    deps += init_dependencies(meta_doc['requires'], Dependency::A_SCOPE_RUNTIME)
+    deps += init_dependencies(meta_doc['build_requires'], Dependency::A_SCOPE_BUILD)
+    deps += init_dependencies(meta_doc['develop_requires'], Dependency::A_SCOPE_DEVELOPMENT)
+
+    deps += init_dependencies(meta_doc['configure_requires'], Dependency::A_SCOPE_CONFIGURE)
+    deps += init_dependencies(meta_doc['test_requires'], Dependency::A_SCOPE_TEST)
+
+    # recommended dependencies
+    deps += init_dependencies(meta_doc['recommends'], Dependency::A_SCOPE_RUNTIME)
+    deps += init_dependencies(meta_doc['build_recommends'], Dependency::A_SCOPE_BUILD)
+    deps += init_dependencies(meta_doc['develop_recommends'], Dependency::A_SCOPE_DEVELOPMENT)
+    deps += init_dependencies(meta_doc['configure_recommends'], Dependency::A_SCOPE_CONFIGURE)
+    deps += init_dependencies(meta_doc['test_recommends'], Dependency::A_SCOPE_TEST)
+
+    # suggested dependencies
+    deps += init_dependencies(meta_doc['suggests'], Dependency::A_SCOPE_RUNTIME)
+    deps += init_dependencies(meta_doc['build_suggests'], Dependency::A_SCOPE_BUILD)
+    deps += init_dependencies(meta_doc['develop_suggests'], Dependency::A_SCOPE_DEVELOPMENT)
+    deps += init_dependencies(meta_doc['configure_suggests'], Dependency::A_SCOPE_CONFIGURE)
+    deps += init_dependencies(meta_doc['test_suggests'], Dependency::A_SCOPE_TEST)
+
+
+    deps
+  end
+
+  def init_dependencies(deps_doc, scope)
+    deps_doc.to_a.reduce([]) do |acc, row|
+      prod_key, version_label = row.to_a
+      acc << init_dependency(prod_key, version_label, scope)
+      acc
+    end.to_a
+  end
+
+  def init_dependency(prod_key, version_label, scope)
+    Projectdependency.new(
+      language: Product::A_LANGUAGE_PERL,
+      prod_key: prod_key,
+      name: prod_key,
+      version_label: version_label,
+      scope: scope.to_s.downcase
+    )
+  end
+
+
+end

--- a/lib/versioneye/parsers/parser_strategy.rb
+++ b/lib/versioneye/parsers/parser_strategy.rb
@@ -96,7 +96,14 @@ class ParserStrategy
         return GodepParser.new
 
       when Project::A_TYPE_CPAN
-        return CpanParser.new
+        case url
+        when /meta\.json/i
+          MetaJsonParser.new
+        when /meta\.ya?ml/i
+          MetaYamlParser.new
+        else
+          return CpanParser.new
+        end
 
       when Project::A_TYPE_CARGO
         if url.match( /Cargo\.lock\z/i )

--- a/lib/versioneye/service.rb
+++ b/lib/versioneye/service.rb
@@ -110,6 +110,7 @@ module Versioneye
     require 'versioneye/parsers/mix_parser'
     require 'versioneye/parsers/rebar3_parser'
     require 'versioneye/parsers/meta_json_parser'
+    require 'versioneye/parsers/meta_yaml_parser'
 
     require 'versioneye/parsers/godep_parser'
     require 'versioneye/parsers/glide_parser'

--- a/lib/versioneye/service.rb
+++ b/lib/versioneye/service.rb
@@ -109,6 +109,7 @@ module Versioneye
     require 'versioneye/parsers/csproj_parser'
     require 'versioneye/parsers/mix_parser'
     require 'versioneye/parsers/rebar3_parser'
+    require 'versioneye/parsers/meta_json_parser'
 
     require 'versioneye/parsers/godep_parser'
     require 'versioneye/parsers/glide_parser'

--- a/spec/fixtures/files/cpan/META.json
+++ b/spec/fixtures/files/cpan/META.json
@@ -1,0 +1,63 @@
+{
+    "name": "Test-CPAN-Meta-JSON",
+    "version": "0.16",
+    "abstract": "Validate your CPAN META.json files",
+    "author": ["Barbie <barbie@cpan.org>"],
+
+    "license": [ "artistic_2" ],
+    "dynamic_config" : 0,
+    "release_status" : "stable",
+    "meta-spec": {
+        "version": "2",
+        "url": "http://search.cpan.org/dist/CPAN-Meta/lib/CPAN/Meta/Spec.pm"
+    },
+    "generated_by": "The Hand of Barbie 1.0",
+    "keywords" : [
+        "qa",
+        "cpan",
+        "testing",
+        "meta",
+        "json"
+    ],
+
+    "prereqs" : {
+        "runtime" : {
+            "requires" : {
+                "perl": "5.006",
+                "IO::File": "0"
+            }
+        },
+        "test" : {
+            "requires": {
+                "Test::More": "0.62"
+            },
+            "recommends": {
+                "Test::CPAN::Meta": "0.13"
+            }
+        }
+    },
+
+    "provides": {
+        "Test::CPAN::Meta::JSON": {
+            "file": "lib/Test/CPAN/Meta/JSON.pm",
+            "version": "0.16"
+        },
+        "Test::CPAN::Meta::JSON::Version": {
+            "file": "lib/Test/CPAN/Meta/JSON/Version.pm",
+            "version": "0.16"
+        }
+    },
+    "no_index": {
+        "directory": ["t","examples"]
+    },
+
+    "resources": {
+        "license": [ "http://www.perlfoundation.org/artistic_license_2_0" ],
+        "bugtracker": { "web": "http://rt.cpan.org/Public/Dist/Display.html?Name=Test-CPAN-Meta-JSON" },
+        "repository": {
+            "url": "git://github.com/barbie/Test-CPAN-Meta-JSON.git",
+            "web": "http://github.com/barbie/Test-CPAN-Meta-JSON",
+            "type": "git"
+        }
+    }
+}

--- a/spec/fixtures/files/cpan/META.yml
+++ b/spec/fixtures/files/cpan/META.yml
@@ -1,0 +1,26 @@
+---
+abstract: 'Official Perl support for all Tinkerforge Bricks and Bricklets'
+author:
+  - 'Ishraq Ibne Ashraf <ishraq@tinkerforge.com>'
+build_requires:
+  Test::More: '0.1'
+configure_requires:
+  ExtUtils::MakeMaker: '0'
+dynamic_config: 1
+generated_by: 'ExtUtils::MakeMaker version 6.66, CPAN::Meta::Converter version 2.150005'
+license: unknown
+meta-spec:
+  url: http://module-build.sourceforge.net/META-spec-v1.4.html
+  version: '1.4'
+name: Tinkerforge
+no_index:
+  directory:
+    - t
+    - inc
+requires:
+  Digest::HMAC_SHA1: '1.0.0'
+  IO::Socket::INET: '2.0.0'
+recommends:
+  Cpanel::JSON::XS: '0'
+version: v2.1.14
+x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/spec/versioneye/parsers/common_parser_spec.rb
+++ b/spec/versioneye/parsers/common_parser_spec.rb
@@ -180,6 +180,10 @@ describe CommonParser do
     it "matches Cpan filenames" do
       expect(CommonParser.cpan_file?('Cpanfile')).to be_truthy
       expect(CommonParser.cpan_file?('/a/b/cpanfile')).to be_truthy
+      expect(CommonParser.cpan_file?('META.json')).to be_truthy
+      expect(CommonParser.cpan_file?('/a/b/META.json')).to be_truthy
+      expect(CommonParser.cpan_file?('META.yml')).to be_truthy
+      expect(CommonParser.cpan_file?('/a/b/META.yml')).to be_truthy
     end
 
     it "misses Cpan looking filenames" do

--- a/spec/versioneye/parsers/meta_json_parser_spec.rb
+++ b/spec/versioneye/parsers/meta_json_parser_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+
+describe MetaJsonParser do
+  let(:parser){ MetaJsonParser.new }
+  let(:test_content){ File.read 'spec/fixtures/files/cpan/META.json' }
+
+  let(:prod1){
+    Product.new(
+      language: Product::A_LANGUAGE_PERL,
+      prod_type: Project::A_TYPE_CPAN,
+      prod_key: 'perl',
+      name: 'perl',
+      version: '5.006'
+    )
+  }
+
+  let(:prod2){
+    Product.new(
+      language: Product::A_LANGUAGE_PERL,
+      prod_type: Project::A_TYPE_CPAN,
+      prod_key: 'IO::File',
+      name: 'IO::File',
+      version: '5.006'
+    )
+  }
+
+  let(:prod3){
+    Product.new(
+      language: Product::A_LANGUAGE_PERL,
+      prod_type: Project::A_TYPE_CPAN,
+      prod_key: 'Test::More',
+      name: 'Test::More',
+      version: '1.0.0'
+    )
+  }
+
+  let(:prod4){
+    Product.new(
+      language: Product::A_LANGUAGE_PERL,
+      prod_type: Project::A_TYPE_CPAN,
+      prod_key: 'Test::CPAN::Meta',
+      name: 'Test::Cpan::Meta',
+      version: '0.13'
+    )
+  }
+
+  context 'parse_dependencies' do
+    it 'returns correct list of dep' do
+      reqs_doc = {
+        runtime: {requires: {'perl' => '1.2.3'}}
+      }
+
+      deps = parser.parse_dependencies(reqs_doc)
+      expect(deps).not_to be_nil
+      expect(deps.size).to eq(1)
+      expect(deps[0][:name]).to eq('perl')
+      expect(deps[0][:version_label]).to eq('1.2.3')
+      expect(deps[0][:scope]).to eq(Dependency::A_SCOPE_RUNTIME)
+    end
+  end
+
+  context 'parse_content' do
+    before do
+      prod1.versions << Version.new(version: '5.006')
+      prod1.save
+
+      prod2.versions << Version.new(version: '5.006')
+      prod2.save
+
+      prod3.versions << Version.new(version: '0.62')
+      prod3.versions << Version.new(version: '1.0.0')
+      prod3.save
+
+      prod4.versions << Version.new(version: '0.13')
+      prod4.save
+    end
+
+    it "parses the testContent correctly" do
+      proj = parser.parse_content test_content
+      expect(proj).not_to be_nil
+      expect(proj.projectdependencies.size).to eq(4)
+
+      dep1 = proj.projectdependencies[0]
+      expect(dep1).not_to be_nil
+      expect(dep1[:language]).to eq(prod1[:language])
+      expect(dep1[:prod_key]).to eq(prod1[:prod_key])
+      expect(dep1[:version_current]).to eq(prod1[:version])
+      expect(dep1[:version_label]).to eq(prod1[:version])
+      expect(dep1[:version_requested]).to eq(prod1[:version])
+      expect(dep1[:comperator]).to eq('>=')
+      expect(dep1[:scope]).to eq(Dependency::A_SCOPE_RUNTIME)
+
+      dep2 = proj.projectdependencies[1]
+      expect(dep2).not_to be_nil
+      expect(dep2[:language]).to eq(prod2[:language])
+      expect(dep2[:prod_key]).to eq(prod2[:prod_key])
+      expect(dep2[:version_current]).to eq(prod2[:version])
+      expect(dep2[:version_label]).to eq('>= 0')
+      expect(dep2[:version_requested]).to eq(prod2[:version])
+      expect(dep2[:comperator]).to eq('>=')
+      expect(dep2[:scope]).to eq(Dependency::A_SCOPE_RUNTIME)
+
+      dep3 = proj.projectdependencies[2]
+      expect(dep3).not_to be_nil
+      expect(dep3[:language]).to eq(prod3[:language])
+      expect(dep3[:prod_key]).to eq(prod3[:prod_key])
+      expect(dep3[:version_current]).to eq(prod3[:version])
+      expect(dep3[:version_label]).to eq('0.62')
+      expect(dep3[:version_requested]).to eq(prod3[:version])
+      expect(dep3[:comperator]).to eq('>=')
+      expect(dep3[:scope]).to eq(Dependency::A_SCOPE_TEST)
+
+      dep4 = proj.projectdependencies[3]
+      expect(dep4).not_to be_nil
+      expect(dep4[:language]).to eq(prod4[:language])
+      expect(dep4[:prod_key]).to eq(prod4[:prod_key])
+      expect(dep4[:version_current]).to eq(prod4[:version])
+      expect(dep4[:version_label]).to eq('0.13')
+      expect(dep4[:version_requested]).to eq(prod4[:version])
+      expect(dep4[:comperator]).to eq('>=')
+      expect(dep4[:scope]).to eq(Dependency::A_SCOPE_TEST)
+
+
+    end
+
+  end
+end

--- a/spec/versioneye/parsers/meta_yaml_parser_spec.rb
+++ b/spec/versioneye/parsers/meta_yaml_parser_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper'
+
+describe MetaYamlParser do
+  let(:parser){ MetaYamlParser.new }
+  let(:test_content){ File.read 'spec/fixtures/files/cpan/META.yml' }
+
+  let(:prod1){
+    Product.new(
+      language: Product::A_LANGUAGE_PERL,
+      prod_type: Project::A_TYPE_CPAN,
+      prod_key: 'Digest::HMAC_SHA1',
+      name: 'Digest::HMAC_SHA1',
+      version: '1.0.0'
+    )
+  }
+
+  let(:prod2){
+    Product.new(
+      language: Product::A_LANGUAGE_PERL,
+      prod_type: Project::A_TYPE_CPAN,
+      prod_key: 'IO::Socket::INET',
+      name: 'IO::Socket::INET',
+      version: '2.0.0'
+    )
+  }
+
+  let(:prod3){
+    Product.new(
+      language: Product::A_LANGUAGE_PERL,
+      prod_type: Project::A_TYPE_CPAN,
+      prod_key: 'Test::More',
+      name: 'Test::More',
+      version: '0.1'
+    )
+  }
+
+  let(:prod4){
+    Product.new(
+      language: Product::A_LANGUAGE_PERL,
+      prod_type: Project::A_TYPE_CPAN,
+      prod_key: 'ExtUtils::MakeMaker',
+      name: 'ExtUtils::MakeMaker',
+      version: '3.0.0'
+    )
+  }
+
+  let(:prod5){
+    Product.new(
+      language: Product::A_LANGUAGE_PERL,
+      prod_type: Project::A_TYPE_CPAN,
+      prod_key: 'Cpanel::JSON::XS',
+      name: 'Cpanel::JSON::XS',
+      version: '5.0.0'
+    )
+  }
+
+  context 'parse_content' do
+    before do
+      prod1.versions << Version.new(version: '1.0.0')
+      prod1.save
+
+      prod2.versions << Version.new(version: '2.0.0')
+      prod2.save
+
+      prod3.versions << Version.new(version: '0.1')
+      prod3.save
+
+      prod4.versions << Version.new(version: '3.0.0')
+      prod4.save
+
+      prod5.versions << Version.new(version: '5.0.0')
+      prod5.save
+    end
+
+    it "parses test file correctly" do
+      proj = parser.parse_content test_content
+      expect(proj).not_to be_nil
+      expect(proj.projectdependencies.size).to eq(5)
+
+      dep1 = proj.projectdependencies[0]
+      expect(dep1[:language]).to eq(prod1[:language])
+      expect(dep1[:prod_key]).to eq(prod1[:prod_key])
+      expect(dep1[:version_current]).to eq(prod1[:version])
+      expect(dep1[:version_label]).to eq('1.0.0')
+      expect(dep1[:version_requested]).to eq('1.0.0')
+      expect(dep1[:comperator]).to eq('>=')
+      expect(dep1[:outdated]).to be_falsey
+
+      dep2 = proj.projectdependencies[1]
+      expect(dep2[:language]).to eq(prod2[:language])
+      expect(dep2[:prod_key]).to eq(prod2[:prod_key])
+      expect(dep2[:version_current]).to eq(prod2[:version])
+      expect(dep2[:version_label]).to eq('2.0.0')
+      expect(dep2[:version_requested]).to eq('2.0.0')
+      expect(dep2[:comperator]).to eq('>=')
+      expect(dep2[:outdated]).to be_falsey
+
+      dep3 = proj.projectdependencies[2]
+      expect(dep3[:language]).to eq(prod3[:language])
+      expect(dep3[:prod_key]).to eq(prod3[:prod_key])
+      expect(dep3[:version_current]).to eq(prod3[:version])
+      expect(dep3[:version_label]).to eq('0.1')
+      expect(dep3[:version_requested]).to eq('0.1')
+      expect(dep3[:comperator]).to eq('>=')
+      expect(dep3[:outdated]).to be_falsey
+
+      dep4 = proj.projectdependencies[3]
+      expect(dep4[:language]).to eq(prod4[:language])
+      expect(dep4[:prod_key]).to eq(prod4[:prod_key])
+      expect(dep4[:version_current]).to eq(prod4[:version])
+      expect(dep4[:version_label]).to eq('>= 0')
+      expect(dep4[:version_requested]).to eq('3.0.0')
+      expect(dep4[:comperator]).to eq('>=')
+      expect(dep4[:outdated]).to be_falsey
+
+      dep5 = proj.projectdependencies[4]
+      expect(dep5[:language]).to eq(prod5[:language])
+      expect(dep5[:prod_key]).to eq(prod5[:prod_key])
+      expect(dep5[:version_current]).to eq(prod5[:version])
+      expect(dep5[:version_label]).to eq('>= 0')
+      expect(dep5[:version_requested]).to eq('5.0.0')
+      expect(dep5[:comperator]).to eq('>=')
+      expect(dep5[:outdated]).to be_falsey
+
+
+    end
+  end
+end

--- a/spec/versioneye/parsers/parser_strategy_spec.rb
+++ b/spec/versioneye/parsers/parser_strategy_spec.rb
@@ -110,6 +110,18 @@ describe ParserStrategy do
       expect( parser.is_a?(CpanParser) ).to be_truthy
     end
 
+    it "returns MetaJsonParser" do
+      parser = ParserStrategy.parser_for(Project::A_TYPE_CPAN, "https://s3.com/META.json")
+      expect( parser.is_a?(MetaJsonParser) ).to be_truthy
+    end
+
+    it "returns MetaYamlParser" do
+      parser = ParserStrategy.parser_for(Project::A_TYPE_CPAN, "https://s3.com/META.yml")
+      expect( parser.is_a?(MetaYamlParser) ).to be_truthy
+    end
+
+
+
     it "returns YarnParser" do
       parser = ParserStrategy.parser_for(Project::A_TYPE_NPM, 'yarn.lock')
       expect( parser.is_a?(YarnParser) ).to be_truthy


### PR DESCRIPTION
Solves #120 , which now completes support for CPAN and the maintainers of Perl packages can now easily check status of dependencies by uploading their `Meta.json` or `Meta.yml` files;