### PR TITLE
Issue708 - add support for GIT and other SCM deps;

### DIFF
--- a/lib/versioneye/models/product.rb
+++ b/lib/versioneye/models/product.rb
@@ -139,7 +139,8 @@ class Product < Versioneye::Model
     return prod if prod
 
     product = Product.find_by_lang_key( lang, key )
-    product = Product.find_by_lang_key( lang, key.downcase ) if product.nil?
+    product ||= Product.find_by_lang_key( lang, key.downcase )
+
     if ( product.nil? && lang.eql?( A_LANGUAGE_NODEJS ) )
       product = Product.where(:language => lang, :prod_key_dc => key.downcase).first
     end

--- a/lib/versioneye/parsers/gemfile_parser.rb
+++ b/lib/versioneye/parsers/gemfile_parser.rb
@@ -22,7 +22,7 @@ class GemfileParser < CommonParser
   # http://gembundler.com/man/gemfile.5.html
   # http://guides.rubygems.org/patterns/#semantic_versioning
   # ps: It handles GITHUB and Git deps on Github like PackageParser
-  def parse( url )
+  def parse( url, token = nil )
     return nil if url.nil? || url.empty?
 
     gemfile = fetch_response_body( url )

--- a/lib/versioneye/parsers/requirements_parser.rb
+++ b/lib/versioneye/parsers/requirements_parser.rb
@@ -115,7 +115,8 @@ class RequirementsParser < CommonParser
     dependency.version_label = String.new(version)
 
     if product.nil?
-      dependency.version_requested = version
+      log.warn "parse_requested_version: no product for `#{dependency}`"
+      dependency.version_requested = 'UNKNOWN'
       return nil
     end
 
@@ -178,10 +179,11 @@ class RequirementsParser < CommonParser
       dependency.version_label = "*"
       dependency.comperator = ">="
 
-    elsif version.match(/\A==/)
+    elsif version.match(/\=\=/)
       # Equals
-      version.gsub!(/\A==/, "")
+      version.gsub!(/\A\=\=/, "")
       version.gsub!(" ", "")
+
       dependency.version_requested = version.strip
       dependency.comperator = "=="
 

--- a/lib/versioneye/parsers/requirements_parser.rb
+++ b/lib/versioneye/parsers/requirements_parser.rb
@@ -286,6 +286,32 @@ class RequirementsParser < CommonParser
     scm_url.fragment.to_s.gsub(/\Aegg\=/, '').to_s.strip
   end
 
+  def github_url?(scm_url)
+    /github\.com/.match?(scm_url.to_s.strip)
+  end
+
+  def scm_line?(scm_line)
+    return false if scm_line.is_a?(String) == false
+
+    return /^(\[?-?\w?\]?\s+)?(git|bzr|hg|svn)/i.match?(scm_line)
+  end
+
+  def init_dependency( product, package_name, comperator = '==')
+    dependency = Projectdependency.new(
+      name: package_name,
+      language: Product::A_LANGUAGE_PYTHON,
+      comperator: comperator,
+      scope: Dependency::A_SCOPE_COMPILE
+    )
+
+    if product
+      dependency.prod_key = product.prod_key
+      dependency.version_current = product.version
+    end
+
+    dependency
+  end
+
   def extract_scm_details(scm_url)
     rev = nil
     scm_path = scm_url.path.to_s
@@ -318,32 +344,6 @@ class RequirementsParser < CommonParser
   rescue
     log.error "extract_repo_name: failed to parse `#{scm_url}` as url"
     nil
-  end
-
-  def github_url?(scm_url)
-    /github\.com/.match?(scm_url.to_s.strip)
-  end
-
-  def scm_line?(scm_line)
-    return false if scm_line.is_a?(String) == false
-
-    return /^(\[?-?\w?\]?\s+)?(git|bzr|hg|svn)/i.match?(scm_line)
-  end
-
-  def init_dependency( product, package_name, comperator = '==')
-    dependency = Projectdependency.new(
-      name: package_name,
-      language: Product::A_LANGUAGE_PYTHON,
-      comperator: comperator,
-      scope: Dependency::A_SCOPE_COMPILE
-    )
-
-    if product
-      dependency.prod_key = product.prod_key
-      dependency.version_current = product.version
-    end
-
-    dependency
   end
 
 

--- a/lib/versioneye/parsers/requirements_parser.rb
+++ b/lib/versioneye/parsers/requirements_parser.rb
@@ -128,35 +128,9 @@ class RequirementsParser < CommonParser
 
     if version.match(/,/)
       # Version Ranges
-      # TODO: check VersionServices for better implementation
-      version_splitted = version.split(",")
-      prod = Product.new
-      prod.versions = product.versions
-      version_splitted.each do |verso|
-        verso.gsub!(" ", "")
-        if verso.match(/\A>=/)
-          verso.gsub!(">=", "")
-          new_range = VersionService.greater_than_or_equal( product.versions, verso, true )
-          prod.versions = new_range
-        elsif verso.match(/\A>/)
-          verso.gsub!(">", "")
-          new_range = VersionService.greater_than( product.versions, verso, true )
-          prod.versions = new_range
-        elsif verso.match(/\A<=/)
-          verso.gsub!("<=", "")
-          new_range = VersionService.smaller_than_or_equal( product.versions, verso, true )
-          prod.versions = new_range
-        elsif verso.match(/\A</)
-          verso.gsub!("<", "")
-          new_range = VersionService.smaller_than( product.versions, verso, true )
-          prod.versions = new_range
-        elsif verso.match(/\A!=/)
-          verso.gsub!("!=", "")
-          new_range = VersionService.newest_but_not( product.versions, verso, true)
-          prod.versions = new_range
-        end
-      end
-      highest_version = VersionService.newest_version_from( prod.versions )
+      range_versions = VersionService.from_or_ranges(prod.versions, version, ',')
+      highest_version = VersionService.newest_version_from range_versions
+
       if highest_version
         dependency.version_requested = highest_version.to_s
       else

--- a/lib/versioneye/parsers/requirements_parser.rb
+++ b/lib/versioneye/parsers/requirements_parser.rb
@@ -356,23 +356,17 @@ class RequirementsParser < CommonParser
     package
   end
 
-  # TODO: refactor as case switch
   def extract_comparator line
-    comparator = nil
-    if line.match(/>=/)
-      comparator = ">="
-    elsif line.match(/>/)
-      comparator = ">"
-    elsif line.match(/<=/)
-      comparator = "<="
-    elsif line.match(/</)
-      comparator = "<"
-    elsif line.match(/!=/)
-      comparator = "!="
-    elsif line.match(/==/)
-      comparator = "=="
+    case line
+    when />=/ then '>='
+    when />/  then '>'
+    when /<=/ then '<='
+    when /</  then '<'
+    when /!=/ then '!='
+    when /==/ then '=='
+    else
+      nil
     end
-    comparator
   end
 
 end

--- a/spec/fixtures/files/pip/requirements.txt
+++ b/spec/fixtures/files/pip/requirements.txt
@@ -1,0 +1,28 @@
+ # This is a test line
+# this is a comment to be ignored
+Django==1.3.1 # This is a comment
+PIL==1.1.7
+South<=0.7.3
+amqplib>=1.0.2
+anyjson==0.3.1
+celery==2.4.6
+certifi==0.0.6
+chardet==1.0.1
+django-celery==2.4.2
+django-emailauth==0.1
+django-facebook==3.4.4
+django-kombu==0.9.4
+django-picklefield==0.1.9
+django-profiles==0.2
+https://bitbucket.org/ubernostrum/django-registration/downloads/django-registration-0.8-alpha-1.tar.gz
+kombu==1.5.1
+meld3==0.6.7
+opentok-python-sdk==0.91.0
+python-dateutil==1.5
+requests==0.9.0
+xmpppy==0.5.0rc1 \
+    --hash=sha256:3ffb26342b3526390646697ed5cde4714d2cc46c50e8a13ced2b303fcb59c11d \
+    --hash=sha256:a483e7891ce3a06dadfc6cb9095b0938aca58940d43576d72e4502b480c085d7 # via pylint
+
+jsmin
+emencia.django.newsletter

--- a/spec/fixtures/files/pip/requirements_scm.txt
+++ b/spec/fixtures/files/pip/requirements_scm.txt
@@ -1,0 +1,30 @@
+# This file allows you to install CKAN extensions related to
+# ckanext-dgu and the dependencies for ckanext-dgu. After running
+# this, some of the installed CKAN extensions have their own
+# pip-requirements.txt to install too.
+#
+# Use it like this:
+#
+#   pip install -r pip-requirements.txt
+
+## ckanext-dgu dependencies
+-r pip-requirements-local.txt
+
+
+## Related extensions
+
+# ckanext-harvest
+-e git+https://github.com/datagovuk/ckanext-harvest.git@2.0#egg=ckanext-harvest
+
+# ckanext-spatial
+-e git+https://github.com/datagovuk/ckanext-spatial.git@dgu#egg=ckanext-spatial
+
+# ckanext-qa
+git+https://github.com/ckan/ckanext-qa.git#egg=ckanext-qa
+
+## Related extension dependencies
+
+# Copied from ckanext-spatial's pip-requirements.txt:
+Shapely>=1.2.13
+owslib
+lxml==3.4.4

--- a/spec/fixtures/files/pip/requirements_scm.txt
+++ b/spec/fixtures/files/pip/requirements_scm.txt
@@ -20,7 +20,7 @@
 -e git+https://github.com/datagovuk/ckanext-spatial.git@dgu#egg=ckanext-spatial
 
 # ckanext-qa
-git+https://github.com/ckan/ckanext-qa.git#egg=ckanext-qa
+git+ssh://github.com/ckan/ckanext-qa.git#egg=ckanext-qa
 
 ## Related extension dependencies
 

--- a/spec/versioneye/parsers/requirements_parser_2_spec.rb
+++ b/spec/versioneye/parsers/requirements_parser_2_spec.rb
@@ -1,60 +1,60 @@
 require 'spec_helper'
 
 describe RequirementsParser do
+  let(:parser){ RequirementsParser.new }
+  let(:test_file_url){ "https://s3.amazonaws.com/veye_test_env/python_2/requirements.txt" }
+  let(:product1){
+    create_product('anyjson', 'anyjson'  , '1.0.0', ['0.3.3', '0.3.4', '1.0.0' ])
+  }
 
   describe "parse" do
+    before do
+      product1.save
+    end
 
     it "parse from https the file correctly" do
-      parser = RequirementsParser.new
-      project = parser.parse("https://s3.amazonaws.com/veye_test_env/python_2/requirements.txt")
-      project.should_not be_nil
+      project = parser.parse test_file_url
+      expect( project ).not_to be_nil
     end
 
     it "parse from http the file correctly" do
-      product1  = create_product('anyjson', 'anyjson'  , '1.0.0', ['0.3.3', '0.3.4', '1.0.0' ])
-
-      parser = RequirementsParser.new
       project = parser.parse("https://s3.amazonaws.com/veye_test_env/python_2/requirements.txt")
-      project.should_not be_nil
-      project.dependencies.size.should eql(49)
+      expect( project ).not_to be_nil
+      expect( project.dependencies.size ).to eql(49)
 
-      dep_01 = fetch_by_prod_key 'anyjson', project.dependencies
-      dep_01.name.should eql("anyjson")
-      dep_01.version_requested.should eql("0.3.3")
-      dep_01.version_current.should eql("1.0.0")
-      dep_01.comperator.should eql("==")
-      dep_01.version_label.should eql('==0.3.3')
-      dep_01.outdated.should be_truthy 
+      dep_01 = fetch_by_prod_key product1[:prod_key], project.dependencies
+
+      expect( dep_01.name ).to eql(product1[:name])
+      expect( dep_01.version_current    ).to eql(product1[:version])
+      expect( dep_01.version_requested  ).to eql("0.3.3")
+      expect( dep_01.comperator     ).to eql("==")
+      expect( dep_01.version_label  ).to eql('==0.3.3')
+      expect( dep_01.outdated       ).to be_truthy
     end
 
   end
 
-  
   def create_product(name, prod_key, version, versions = nil )
-    product = Product.new({ :language => Product::A_LANGUAGE_PYTHON, :prod_type => Project::A_TYPE_PIP })
-    product.name = name
-    product.prod_key = prod_key
-    product.version = version
-    product.add_version( version )
-    product.save
+    product = Product.new(
+      language: Product::A_LANGUAGE_PYTHON,
+      prod_type: Project::A_TYPE_PIP,
+      name: name,
+      prod_key: prod_key,
+      version: version
+    )
 
-    return product if !versions
-
-    versions.each do |ver|
-      product.add_version( ver )
+    product.versions << Version.new(version: version ) if version
+    versions.to_a.each do |ver|
+      product.versions << Version.new(version: ver )
     end
-    product.save
 
     product
   end
 
-  
   def fetch_by_prod_key( name, dependencies )
-    dependencies.each do |dep| 
+    dependencies.each do |dep|
       return dep if dep.prod_key.eql?(name)
     end
-    nil 
+    nil
   end
-
-
 end

--- a/spec/versioneye/parsers/requirements_parser_scm_spec.rb
+++ b/spec/versioneye/parsers/requirements_parser_scm_spec.rb
@@ -1,0 +1,107 @@
+require 'uri'
+
+require 'spec_helper'
+
+describe RequirementsParser do
+  let(:parser){ RequirementsParser.new }
+
+  describe "extract_egg_name" do
+    it "returns correct name for git urls" do
+      u = URI.parse( 'git://git.myproject.org/MyProject.git#egg=MyProject' )
+      expect(parser.extract_egg_name(u)).to eq('MyProject')
+    end
+
+    it "returns correct name for git urls with revision details" do
+      u = URI.parse 'git://git.myproject.org/MyProject.git@da39a3ee5e6b4b0d3255bfef95601890afd80709#egg=MyProject'
+      expect(parser.extract_egg_name(u)).to eq('MyProject')
+    end
+  end
+
+  describe "extract_scm_path" do
+    it "returns path and no rev details" do
+      u = URI.parse( 'git://git.myproject.org/MyProject.git#egg=MyProject' )
+      path, rev = parser.extract_scm_details(u)
+
+      expect(path).to eq('/MyProject.git')
+      expect(rev).to be_nil
+    end
+
+    it "returns correct path and rev details" do
+      u = URI.parse( 'git://git.myproject.org/MyProject.git@2.1.0-alpha#egg=MyProject' )
+      path, rev = parser.extract_scm_details(u)
+
+      expect(path).to eq('/MyProject.git')
+      expect(rev).to eq('2.1.0-alpha')
+    end
+  end
+
+  describe "scm_line?" do
+    it "returns false for empty string" do
+      expect(parser.scm_line?('')).to be_falsey
+    end
+
+    it "returns true for git line" do
+      t = 'git+https://github.com/datagovuk/ckanext-harvest.git@2.0#egg=ckanext-harvest'
+      expect(parser.scm_line?(t)).to be_truthy
+    end
+
+    it "returns true for hg line" do
+      t = 'hg+https://hg.myproject.org/MyProject/#egg=MyProject'
+      expect(parser.scm_line?(t)).to be_truthy
+    end
+
+    it "returns true for bzr line" do
+      t = 'bzr+ftp://user@myproject.org/MyProject/trunk/#egg=MyProject'
+      expect(parser.scm_line?(t)).to be_truthy
+    end
+
+    it "returns true svn line" do
+      t = 'svn+svn://svn.myproject.org/svn/MyProject#egg=MyProject'
+      expect(parser.scm_line?(t)).to be_truthy
+    end
+
+    it "ignores `-e` flag in the prefix" do
+      t = '-e git://git.myproject.org/MyProject.git#egg=MyProject'
+      expect(parser.scm_line?(t)).to be_truthy
+    end
+  end
+
+  describe "extract_git_fullname" do
+    it "returns correct repo fullname for basic url" do
+      t = 'git+https://github.com/ckan/ckanext-qa'
+      expect(parser.extract_git_fullname(t)).to eql('ckan/ckanext-qa')
+    end
+
+    it "returns repo fullname for github repo and ignore revision details" do
+      t = 'git+https://github.com/datagovuk/ckanext-harvest.git@2.0#egg=ckanext-harvest'
+      expect(parser.extract_git_fullname(t)).to eq('datagovuk/ckanext-harvest')
+    end
+  end
+
+  describe "process_scm_line" do
+
+    it "returns correct PIP line for git" do
+      t = 'git+https://gitnob.com/datagovuk/ckanext-harvest.git@2.0#egg=ckanext-harvest'
+      expected = 'ckanext-harvest==git+https://gitnob.com/datagovuk/ckanext-harvest.git#2.0'
+
+      egg_line = parser.process_scm_line(t)
+      expect(egg_line).to eq(expected)
+    end
+
+    it "returns correct PIP line for HG" do
+      t = 'hg+ssh://hg@myproject.org/MyProject/#egg=MyProject'
+      expected = 'MyProject==hg+ssh://myproject.org/MyProject'
+
+      expect(parser.process_scm_line(t)).to eq(expected)
+    end
+
+    it "returns Github repo and rev for Github urls" do
+      t = '-e git+https://github.com/datagovuk/ckanext-harvest.git@2.0#egg=ckanext-harvest'
+      expected = 'ckanext-harvest==datagovuk/ckanext-harvest#2.0'
+
+      expect(parser.process_scm_line(t)).to eq(expected)
+    end
+  end
+
+
+end

--- a/spec/versioneye/parsers/requirements_parser_scm_spec.rb
+++ b/spec/versioneye/parsers/requirements_parser_scm_spec.rb
@@ -104,4 +104,147 @@ describe RequirementsParser do
   end
 
 
+  # tests for parsing the test file content
+  let(:test_content){ File.read 'spec/fixtures/files/pip/requirements_scm.txt' }
+  let(:prod1){
+    Product.new(
+      language: Product::A_LANGUAGE_PYTHON,
+      prod_type: Project::A_TYPE_PIP,
+      prod_key: 'ckanext-harvest',
+      name: 'ckanext-harvest',
+      version: '2.0'
+    )
+  }
+
+  let(:prod2){
+    Product.new(
+      language: Product::A_LANGUAGE_PYTHON,
+      prod_type: Project::A_TYPE_PIP,
+      prod_key: 'ckanext-spatial',
+      name: 'ckanext-spatial',
+      version: '1.0.0'
+    )
+  }
+
+  let(:prod3){
+    Product.new(
+      language: Product::A_LANGUAGE_PYTHON,
+      prod_type: Project::A_TYPE_PIP,
+      prod_key: 'ckanext-qa',
+      name: 'ckanext-qa',
+      version: '1.3.0'
+    )
+  }
+
+  let(:prod4){
+    Product.new(
+      language: Product::A_LANGUAGE_PYTHON,
+      prod_type: Project::A_TYPE_PIP,
+      prod_key: 'Shapely',
+      name: 'Shapely',
+      version: '1.2.13'
+    )
+  }
+
+  let(:prod5){
+    Product.new(
+      language: Product::A_LANGUAGE_PYTHON,
+      prod_type: Project::A_TYPE_PIP,
+      prod_key: 'owslib',
+      name: 'owslib',
+      version: '1.4.1'
+    )
+  }
+
+  let(:prod6){
+    Product.new(
+      language: Product::A_LANGUAGE_PYTHON,
+      prod_type: Project::A_TYPE_PIP,
+      prod_key: 'lxml',
+      name: 'lxml',
+      version: '3.4.4'
+    )
+  }
+
+
+  describe 'parse_content' do
+    before do
+      prod1.versions << Version.new(version: '2.0')
+      prod1.save
+
+      prod2.versions << Version.new(version: '1.0.0')
+      prod2.save
+
+      prod3.save
+
+      prod4.versions << Version.new(version: '1.2.13')
+      prod4.save
+
+      prod5.versions << Version.new(version: '1.4.1')
+      prod5.save
+
+      prod6.save
+    end
+
+    it 'parses correctly the test file with SCM deps' do
+      proj = parser.parse_content(test_content)
+      expect(proj).not_to be_nil
+      expect(proj.projectdependencies.size).to eq(6)
+
+      dep1 = proj.projectdependencies[0]
+      expect(dep1[:prod_key]).to eq(prod1[:prod_key])
+      expect(dep1[:language]).to eq(prod1[:language])
+      expect(dep1[:version_current]).to eq(prod1[:version])
+      expect(dep1[:version_requested]).to eq('datagovuk/ckanext-harvest#2.0')
+      expect(dep1[:version_label]).to eq('==datagovuk/ckanext-harvest#2.0')
+      expect(dep1[:comperator]).to eq('==')
+      expect(dep1[:outdated]).to be_truthy
+
+      dep2 = proj.projectdependencies[1]
+      expect(dep2[:prod_key]).to eq(prod2[:prod_key])
+      expect(dep2[:language]).to eq(prod2[:language])
+      expect(dep2[:version_current]).to eq(prod2[:version])
+      expect(dep2[:version_requested]).to eq('datagovuk/ckanext-spatial#dgu')
+      expect(dep2[:version_label]).to eq('==datagovuk/ckanext-spatial#dgu')
+      expect(dep2[:comperator]).to eq('==')
+      expect(dep2[:outdated]).to be_truthy
+
+      dep3 = proj.projectdependencies[2]
+      expect(dep3[:prod_key]).to eq(prod3[:prod_key])
+      expect(dep3[:language]).to eq(prod3[:language])
+      expect(dep3[:version_current]).to eq(prod3[:version])
+      expect(dep3[:version_requested]).to eq('ckan/ckanext-qa')
+      expect(dep3[:version_label]).to eq('==ckan/ckanext-qa')
+      expect(dep3[:comperator]).to eq('==')
+      expect(dep3[:outdated]).to be_truthy
+
+      dep4 = proj.projectdependencies[3]
+      expect(dep4[:prod_key]).to eq(prod4[:prod_key])
+      expect(dep4[:language]).to eq(prod4[:language])
+      expect(dep4[:version_current]).to eq(prod4[:version])
+      expect(dep4[:version_requested]).to eq('1.2.13')
+      expect(dep4[:version_label]).to eq('>=1.2.13')
+      expect(dep4[:comperator]).to eq('>=')
+      expect(dep4[:outdated]).to be_falsey
+
+      dep5 = proj.projectdependencies[4]
+      expect(dep5[:prod_key]).to eq(prod5[:prod_key])
+      expect(dep5[:language]).to eq(prod5[:language])
+      expect(dep5[:version_current]).to eq(prod5[:version])
+      expect(dep5[:version_requested]).to eq('1.4.1')
+      expect(dep5[:version_label]).to eq('1.4.1')
+      expect(dep5[:comperator]).to eq('>=')
+      expect(dep5[:outdated]).to be_falsey
+
+      dep6 = proj.projectdependencies[5]
+      expect(dep6[:prod_key]).to eq(prod6[:prod_key])
+      expect(dep6[:language]).to eq(prod6[:language])
+      expect(dep6[:version_current]).to eq(prod6[:version])
+      expect(dep6[:version_requested]).to eq('3.4.4')
+      expect(dep6[:version_label]).to eq('==3.4.4')
+      expect(dep6[:comperator]).to eq('==')
+      expect(dep6[:outdated]).to be_falsey
+
+    end
+  end
 end

--- a/spec/versioneye/parsers/requirements_parser_scm_spec.rb
+++ b/spec/versioneye/parsers/requirements_parser_scm_spec.rb
@@ -195,28 +195,28 @@ describe RequirementsParser do
       expect(dep1[:prod_key]).to eq(prod1[:prod_key])
       expect(dep1[:language]).to eq(prod1[:language])
       expect(dep1[:version_current]).to eq(prod1[:version])
-      expect(dep1[:version_requested]).to eq('datagovuk/ckanext-harvest#2.0')
+      expect(dep1[:version_requested]).to eq('GITHUB')
       expect(dep1[:version_label]).to eq('==datagovuk/ckanext-harvest#2.0')
       expect(dep1[:comperator]).to eq('==')
-      expect(dep1[:outdated]).to be_truthy
+      expect(dep1[:outdated]).to be_falsey
 
       dep2 = proj.projectdependencies[1]
       expect(dep2[:prod_key]).to eq(prod2[:prod_key])
       expect(dep2[:language]).to eq(prod2[:language])
       expect(dep2[:version_current]).to eq(prod2[:version])
-      expect(dep2[:version_requested]).to eq('datagovuk/ckanext-spatial#dgu')
+      expect(dep2[:version_requested]).to eq('GITHUB')
       expect(dep2[:version_label]).to eq('==datagovuk/ckanext-spatial#dgu')
       expect(dep2[:comperator]).to eq('==')
-      expect(dep2[:outdated]).to be_truthy
+      expect(dep2[:outdated]).to be_falsey
 
       dep3 = proj.projectdependencies[2]
       expect(dep3[:prod_key]).to eq(prod3[:prod_key])
       expect(dep3[:language]).to eq(prod3[:language])
       expect(dep3[:version_current]).to eq(prod3[:version])
-      expect(dep3[:version_requested]).to eq('ckan/ckanext-qa')
+      expect(dep3[:version_requested]).to eq('GITHUB')
       expect(dep3[:version_label]).to eq('==ckan/ckanext-qa')
       expect(dep3[:comperator]).to eq('==')
-      expect(dep3[:outdated]).to be_truthy
+      expect(dep3[:outdated]).to be_falsey
 
       dep4 = proj.projectdependencies[3]
       expect(dep4[:prod_key]).to eq(prod4[:prod_key])

--- a/spec/versioneye/parsers/requirements_parser_spec.rb
+++ b/spec/versioneye/parsers/requirements_parser_spec.rb
@@ -1,116 +1,116 @@
 require 'spec_helper'
 
 describe RequirementsParser do
+  let(:parser){ RequirementsParser.new }
+  let(:test_content){ File.read 'spec/fixtures/files/pip/requirements.txt' }
+
+  let(:product1){
+    create_product('South'  , 'south'  , '1.0.0', ['0.7.3', '0.7.2', '1.0.0' ])
+  }
+  let(:product2){
+    create_product('amqplib', 'amqplib', '2.0.0', ['1.0.2', '1.0.0', '2.0.0' ])
+  }
+  let(:product3){
+    create_product('Django' , 'django' , '1.4.0', ['1.3.1', '1.3.5', '1.4.0' ])
+  }
+  let(:product4){ create_product('PIL'    , 'pil'    , '1.1.7' ) }
+  let(:product5){ create_product('jsmin'  , 'jsmin'  , '1.1.7' ) }
+
 
   describe "parse" do
-
-    it "parse from https the file correctly" do
-      parser = RequirementsParser.new
-      project = parser.parse("https://s3.amazonaws.com/veye_test_env/requirements.txt")
-      project.should_not be_nil
+    before do
+      product1.save
+      product2.save
+      product3.save
+      product4.save
+      product5.save
     end
 
     it "parse from http the file correctly" do
+      project = parser.parse_content test_content
+      expect( project ).not_to be_nil
+      expect( project.dependencies.size ).to eql(22)
 
-      product1  = create_product('South'  , 'south'  , '1.0.0', ['0.7.3', '0.7.2', '1.0.0' ])
-      product2  = create_product('amqplib', 'amqplib', '2.0.0', ['1.0.2', '1.0.0', '2.0.0' ])
-      product3  = create_product('Django' , 'django' , '1.4.0', ['1.3.1', '1.3.5', '1.4.0' ])
-      product4  = create_product('PIL'    , 'pil'    , '1.1.7' )
-      product5  = create_product('jsmin'  , 'jsmin'  , '1.1.7' )
-
-      parser = RequirementsParser.new
-      project = parser.parse("http://s3.amazonaws.com/veye_test_env/requirements.txt")
-      project.should_not be_nil
-      project.dependencies.size.should eql(22)
-
-      dep_01 = project.dependencies.first
-      dep_01.name.should eql("Django")
-      dep_01.version_requested.should eql("1.3.1")
-      dep_01.version_current.should eql("1.4.0")
-      dep_01.comperator.should eql("==")
+      dep_01 = project.dependencies[0]
+      expect( dep_01.name ).to eql(product3[:name])
+      expect( dep_01.version_requested ).to eql("1.3.1")
+      expect( dep_01.version_current ).to eql(product3[:version])
+      expect( dep_01.comperator ).to eql("==")
 
       dep_02 = project.dependencies[1]
-      dep_02.name.should eql("PIL")
-      dep_02.version_requested.should eql("1.1.7")
-      dep_02.version_current.should eql("1.1.7")
-      dep_02.comperator.should eql("==")
+      expect( dep_02.name ).to eql(product4[:name])
+      expect( dep_02.version_requested  ).to eql(product4[:version])
+      expect( dep_02.version_current    ).to eql(product4[:version])
+      expect( dep_02.comperator         ).to eql("==")
 
       dep_03 = project.dependencies[2]
-      dep_03.name.should eql("South")
-      dep_03.version_requested.should eql("0.7.3")
-      dep_03.version_current.should eql("1.0.0")
-      dep_03.comperator.should eql("<=")
+      expect( dep_03.name ).to eql(product1[:name])
+      expect( dep_03.version_requested  ).to eql("0.7.3")
+      expect( dep_03.version_current    ).to eql(product1[:version])
+      expect( dep_03.comperator         ).to eql("<=")
 
       dep_04 = project.dependencies[3]
-      dep_04.name.should eql("amqplib")
-      dep_04.version_requested.should eql("2.0.0")
-      dep_04.version_current.should eql("2.0.0")
-      dep_04.comperator.should eql(">=")
+      expect( dep_04.name ).to eql(product2[:name])
+      expect( dep_04.version_requested  ).to eql(product2[:version])
+      expect( dep_04.version_current    ).to eql(product2[:version])
+      expect( dep_04.comperator         ).to eql(">=")
 
       dep_05 = project.dependencies[20]
-      dep_05.name.should eql("jsmin")
-      dep_05.version_requested.should eql("1.1.7")
-      dep_05.version_current.should eql("1.1.7")
-      dep_05.comperator.should eql(nil)
+      expect( dep_05.name ).to eql(product5[:name])
+      expect( dep_05.version_requested  ).to eql(product5[:version])
+      expect( dep_05.version_current    ).to eql(product5[:version])
+      expect( dep_05.comperator         ).to eql('>=')
 
-      project.dependencies.last.name.should eql("emencia.django.newsletter")
+      expect( project.dependencies.last.name ).to eql("emencia.django.newsletter")
     end
 
   end
 
   describe "extract_comparator" do
 
-    it "returns the right splitt ==" do
-      parser = RequirementsParser.new
-      parser.extract_comparator("django==1.0").should eql("==")
+    it "returns the right split ==" do
+      expect( parser.extract_comparator("django==1.0") ).to eql("==")
     end
 
-    it "returns the right splitt <" do
-      parser = RequirementsParser.new
-      parser.extract_comparator("django<1.0").should eql("<")
+    it "returns the right split <" do
+      expect( parser.extract_comparator("django<1.0") ).to eql("<")
     end
 
     it "returns the right splitt <=" do
-      parser = RequirementsParser.new
-      parser.extract_comparator("django<=1.0").should eql("<=")
+      expect( parser.extract_comparator("django<=1.0") ).to eql("<=")
     end
 
     it "returns the right splitt >" do
-      parser = RequirementsParser.new
-      parser.extract_comparator("django>1.0").should eql(">")
+      expect( parser.extract_comparator("django>1.0") ).to eql(">")
     end
 
     it "returns the right splitt >=" do
-      parser = RequirementsParser.new
-      parser.extract_comparator("django>=1.0").should eql(">=")
+      expect( parser.extract_comparator("django>=1.0") ).to eql(">=")
     end
 
     it "returns the right splitt !=" do
-      parser = RequirementsParser.new
-      parser.extract_comparator("django!=1.0").should eql("!=")
+      expect( parser.extract_comparator("django!=1.0") ).to eql("!=")
     end
 
     it "returns nil" do
-      parser = RequirementsParser.new
-      parser.extract_comparator("django").should be_nil
+      expect( parser.extract_comparator("django") ).to be_nil
     end
 
   end
 
   def create_product(name, prod_key, version, versions = nil )
-    product = Product.new({ :language => Product::A_LANGUAGE_PYTHON, :prod_type => Project::A_TYPE_PIP })
-    product.name = name
-    product.prod_key = prod_key
-    product.version = version
-    product.add_version( version )
-    product.save
+    product = Product.new(
+      language: Product::A_LANGUAGE_PYTHON,
+      prod_type: Project::A_TYPE_PIP,
+      name: name,
+      prod_key: prod_key,
+      version: version
+    )
 
-    return product if !versions
-
-    versions.each do |ver|
-      product.add_version( ver )
+    product.versions << Version.new(version: version ) if version
+    versions.to_a.each do |ver|
+      product.versions << Version.new(version: ver )
     end
-    product.save
 
     product
   end


### PR DESCRIPTION
Hi,

it's rather large PR, which solves the issue [#708](https://github.com/versioneye/versioneye/issues/708) and does some enhancements for `RequirementsParser`:

* it adds support for urls of VersionControl systems; used the specification of [PIP version control](https://pip.readthedocs.io/en/1.1/requirements.html#version-control) for that
* removed deprecation warnings from all the  `requirements_parser_*` specs
* add support for the `GithubComperator`, which allows to check up the state of `repo_ref` when the `token` parameter is set;
* use the `VersionService` to find highest version from the version range;
* some small enhancements as the implementation of `RequirementsParser` was quite old
