### PR TITLE
fix failing jspm_parser_spec;

### DIFF
--- a/spec/versioneye/parsers/jspm_parser_spec.rb
+++ b/spec/versioneye/parsers/jspm_parser_spec.rb
@@ -82,7 +82,7 @@ describe PackageParser do
       expect(dep2[:prod_key]).to eq(plugin_babel[:prod_key])
       expect(dep2[:language]).to eq(plugin_babel[:language])
       expect(dep2[:scope]).to eq("jspm_#{Dependency::A_SCOPE_DEVELOPMENT}")
-      expect(dep2[:version_requested]).to eq('0.0.8')
+      expect(dep2[:version_requested]).to eq('0.0.5')
       expect(dep2[:version_label]).to eq('^0.0.5')
       expect(dep2[:comperator]).to eq('^')
       expect(dep2[:outdated]).to be_truthy


### PR DESCRIPTION
I noticed that build was broken after you merged my PR;

And it was because it catched another bug in old NPMParser, which solved `^0.0.5` to `^0.0.8`, but should be `0.0.5`. I also double check the case with Node's `semver` package:

```javascript
npm install semver
node

> var semver = require('semver')
undefined
> semver.satisfies('0.0.8', '^0.0.5') 
false
```